### PR TITLE
[tester] Add time limit specific to each CTS test

### DIFF
--- a/tester/config.py
+++ b/tester/config.py
@@ -77,6 +77,18 @@ def get_cts_test_arguments(test_category: str, test_name: str) -> List[str]:
     raise KeyError(f"Test {test_category}/{test_name} definition was not found")
 
 
+def get_cts_test_time_limit(test_category: str, test_name: str) -> int:
+    """
+    Get a the time limit for the given OpenCL CTS test.
+    """
+    test_list = get_cts_test_list()
+    for test in test_list:
+        if test["test_category"] == test_category and test["test_name"] == test_name:
+            return test["time_limit"]
+
+    raise KeyError(f"Test {test_category}/{test_name} definition was not found")
+
+
 def get_tested_repository_build_path() -> str:
     """
     Get the absolute path to the tested repository build directory.

--- a/tester/cts.json
+++ b/tester/cts.json
@@ -3,7687 +3,8968 @@
         "test_name": "buffer",
         "test_category": "allocations",
         "executable_path": "test_conformance/allocations/bin/test_allocations",
-        "arguments": "buffer"
+        "arguments": "buffer",
+        "time_limit": 120
     },
     {
         "test_name": "image2d_read",
         "test_category": "allocations",
         "executable_path": "test_conformance/allocations/bin/test_allocations",
-        "arguments": "image2d_read"
+        "arguments": "image2d_read",
+        "time_limit": 120
     },
     {
         "test_name": "image2d_write",
         "test_category": "allocations",
         "executable_path": "test_conformance/allocations/bin/test_allocations",
-        "arguments": "image2d_write"
+        "arguments": "image2d_write",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_non_blocking",
         "test_category": "allocations",
         "executable_path": "test_conformance/allocations/bin/test_allocations",
-        "arguments": "buffer_non_blocking"
+        "arguments": "buffer_non_blocking",
+        "time_limit": 120
     },
     {
         "test_name": "image2d_read_non_blocking",
         "test_category": "allocations",
         "executable_path": "test_conformance/allocations/bin/test_allocations",
-        "arguments": "image2d_read_non_blocking"
+        "arguments": "image2d_read_non_blocking",
+        "time_limit": 120
     },
     {
         "test_name": "image2d_write_non_blocking",
         "test_category": "allocations",
         "executable_path": "test_conformance/allocations/bin/test_allocations",
-        "arguments": "image2d_write_non_blocking"
+        "arguments": "image2d_write_non_blocking",
+        "time_limit": 120
     },
     {
         "test_name": "get_platform_info",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "get_platform_info"
+        "arguments": "get_platform_info",
+        "time_limit": 120
     },
     {
         "test_name": "get_sampler_info",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "get_sampler_info"
+        "arguments": "get_sampler_info",
+        "time_limit": 120
     },
     {
         "test_name": "get_sampler_info_compatibility",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "get_sampler_info_compatibility"
+        "arguments": "get_sampler_info_compatibility",
+        "time_limit": 120
     },
     {
         "test_name": "get_command_queue_info",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "get_command_queue_info"
+        "arguments": "get_command_queue_info",
+        "time_limit": 120
     },
     {
         "test_name": "get_command_queue_info_compatibility",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "get_command_queue_info_compatibility"
+        "arguments": "get_command_queue_info_compatibility",
+        "time_limit": 120
     },
     {
         "test_name": "get_context_info",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "get_context_info"
+        "arguments": "get_context_info",
+        "time_limit": 120
     },
     {
         "test_name": "get_device_info",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "get_device_info"
+        "arguments": "get_device_info",
+        "time_limit": 120
     },
     {
         "test_name": "enqueue_task",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "enqueue_task"
+        "arguments": "enqueue_task",
+        "time_limit": 120
     },
     {
         "test_name": "binary_get",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "binary_get"
+        "arguments": "binary_get",
+        "time_limit": 120
     },
     {
         "test_name": "binary_create",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "binary_create"
+        "arguments": "binary_create",
+        "time_limit": 120
     },
     {
         "test_name": "kernel_required_group_size",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "kernel_required_group_size"
+        "arguments": "kernel_required_group_size",
+        "time_limit": 120
     },
     {
         "test_name": "release_kernel_order",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "release_kernel_order"
+        "arguments": "release_kernel_order",
+        "time_limit": 120
     },
     {
         "test_name": "release_during_execute",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "release_during_execute"
+        "arguments": "release_during_execute",
+        "time_limit": 120
     },
     {
         "test_name": "load_single_kernel",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "load_single_kernel"
+        "arguments": "load_single_kernel",
+        "time_limit": 120
     },
     {
         "test_name": "load_two_kernels",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "load_two_kernels"
+        "arguments": "load_two_kernels",
+        "time_limit": 120
     },
     {
         "test_name": "load_two_kernels_in_one",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "load_two_kernels_in_one"
+        "arguments": "load_two_kernels_in_one",
+        "time_limit": 120
     },
     {
         "test_name": "load_two_kernels_manually",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "load_two_kernels_manually"
+        "arguments": "load_two_kernels_manually",
+        "time_limit": 120
     },
     {
         "test_name": "get_program_info_kernel_names",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "get_program_info_kernel_names"
+        "arguments": "get_program_info_kernel_names",
+        "time_limit": 120
     },
     {
         "test_name": "get_kernel_arg_info",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "get_kernel_arg_info"
+        "arguments": "get_kernel_arg_info",
+        "time_limit": 120
     },
     {
         "test_name": "create_kernels_in_program",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "create_kernels_in_program"
+        "arguments": "create_kernels_in_program",
+        "time_limit": 120
     },
     {
         "test_name": "get_kernel_info",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "get_kernel_info"
+        "arguments": "get_kernel_info",
+        "time_limit": 120
     },
     {
         "test_name": "kernel_private_memory_size",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "kernel_private_memory_size"
+        "arguments": "kernel_private_memory_size",
+        "time_limit": 120
     },
     {
         "test_name": "execute_kernel_local_sizes",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "execute_kernel_local_sizes"
+        "arguments": "execute_kernel_local_sizes",
+        "time_limit": 120
     },
     {
         "test_name": "set_kernel_arg_by_index",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "set_kernel_arg_by_index"
+        "arguments": "set_kernel_arg_by_index",
+        "time_limit": 120
     },
     {
         "test_name": "set_kernel_arg_constant",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "set_kernel_arg_constant"
+        "arguments": "set_kernel_arg_constant",
+        "time_limit": 120
     },
     {
         "test_name": "set_kernel_arg_struct_array",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "set_kernel_arg_struct_array"
+        "arguments": "set_kernel_arg_struct_array",
+        "time_limit": 120
     },
     {
         "test_name": "kernel_global_constant",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "kernel_global_constant"
+        "arguments": "kernel_global_constant",
+        "time_limit": 120
     },
     {
         "test_name": "kernel_attributes",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "kernel_attributes"
+        "arguments": "kernel_attributes",
+        "time_limit": 120
     },
     {
         "test_name": "min_max_thread_dimensions",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "min_max_thread_dimensions"
+        "arguments": "min_max_thread_dimensions",
+        "time_limit": 120
     },
     {
         "test_name": "min_max_work_items_sizes",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "min_max_work_items_sizes"
+        "arguments": "min_max_work_items_sizes",
+        "time_limit": 120
     },
     {
         "test_name": "min_max_work_group_size",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "min_max_work_group_size"
+        "arguments": "min_max_work_group_size",
+        "time_limit": 120
     },
     {
         "test_name": "min_max_read_image_args",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "min_max_read_image_args"
+        "arguments": "min_max_read_image_args",
+        "time_limit": 120
     },
     {
         "test_name": "min_max_write_image_args",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "min_max_write_image_args"
+        "arguments": "min_max_write_image_args",
+        "time_limit": 120
     },
     {
         "test_name": "min_max_mem_alloc_size",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "min_max_mem_alloc_size"
+        "arguments": "min_max_mem_alloc_size",
+        "time_limit": 120
     },
     {
         "test_name": "min_max_image_2d_width",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "min_max_image_2d_width"
+        "arguments": "min_max_image_2d_width",
+        "time_limit": 120
     },
     {
         "test_name": "min_max_image_2d_height",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "min_max_image_2d_height"
+        "arguments": "min_max_image_2d_height",
+        "time_limit": 120
     },
     {
         "test_name": "min_max_image_3d_width",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "min_max_image_3d_width"
+        "arguments": "min_max_image_3d_width",
+        "time_limit": 120
     },
     {
         "test_name": "min_max_image_3d_height",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "min_max_image_3d_height"
+        "arguments": "min_max_image_3d_height",
+        "time_limit": 120
     },
     {
         "test_name": "min_max_image_3d_depth",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "min_max_image_3d_depth"
+        "arguments": "min_max_image_3d_depth",
+        "time_limit": 120
     },
     {
         "test_name": "min_max_image_array_size",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "min_max_image_array_size"
+        "arguments": "min_max_image_array_size",
+        "time_limit": 120
     },
     {
         "test_name": "min_max_image_buffer_size",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "min_max_image_buffer_size"
+        "arguments": "min_max_image_buffer_size",
+        "time_limit": 120
     },
     {
         "test_name": "min_max_parameter_size",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "min_max_parameter_size"
+        "arguments": "min_max_parameter_size",
+        "time_limit": 120
     },
     {
         "test_name": "min_max_samplers",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "min_max_samplers"
+        "arguments": "min_max_samplers",
+        "time_limit": 120
     },
     {
         "test_name": "min_max_constant_buffer_size",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "min_max_constant_buffer_size"
+        "arguments": "min_max_constant_buffer_size",
+        "time_limit": 120
     },
     {
         "test_name": "min_max_constant_args",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "min_max_constant_args"
+        "arguments": "min_max_constant_args",
+        "time_limit": 120
     },
     {
         "test_name": "min_max_compute_units",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "min_max_compute_units"
+        "arguments": "min_max_compute_units",
+        "time_limit": 120
     },
     {
         "test_name": "min_max_address_bits",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "min_max_address_bits"
+        "arguments": "min_max_address_bits",
+        "time_limit": 120
     },
     {
         "test_name": "min_max_single_fp_config",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "min_max_single_fp_config"
+        "arguments": "min_max_single_fp_config",
+        "time_limit": 120
     },
     {
         "test_name": "min_max_double_fp_config",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "min_max_double_fp_config"
+        "arguments": "min_max_double_fp_config",
+        "time_limit": 120
     },
     {
         "test_name": "min_max_local_mem_size",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "min_max_local_mem_size"
+        "arguments": "min_max_local_mem_size",
+        "time_limit": 120
     },
     {
         "test_name": "min_max_kernel_preferred_work_group_size_multiple",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "min_max_kernel_preferred_work_group_size_multiple"
+        "arguments": "min_max_kernel_preferred_work_group_size_multiple",
+        "time_limit": 120
     },
     {
         "test_name": "min_max_execution_capabilities",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "min_max_execution_capabilities"
+        "arguments": "min_max_execution_capabilities",
+        "time_limit": 120
     },
     {
         "test_name": "min_max_queue_properties",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "min_max_queue_properties"
+        "arguments": "min_max_queue_properties",
+        "time_limit": 120
     },
     {
         "test_name": "min_max_device_version",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "min_max_device_version"
+        "arguments": "min_max_device_version",
+        "time_limit": 120
     },
     {
         "test_name": "min_max_language_version",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "min_max_language_version"
+        "arguments": "min_max_language_version",
+        "time_limit": 120
     },
     {
         "test_name": "kernel_arg_changes",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "kernel_arg_changes"
+        "arguments": "kernel_arg_changes",
+        "time_limit": 120
     },
     {
         "test_name": "kernel_arg_multi_setup_random",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "kernel_arg_multi_setup_random"
+        "arguments": "kernel_arg_multi_setup_random",
+        "time_limit": 120
     },
     {
         "test_name": "native_kernel",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "native_kernel"
+        "arguments": "native_kernel",
+        "time_limit": 120
     },
     {
         "test_name": "create_context_from_type",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "create_context_from_type"
+        "arguments": "create_context_from_type",
+        "time_limit": 120
     },
     {
         "test_name": "platform_extensions",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "platform_extensions"
+        "arguments": "platform_extensions",
+        "time_limit": 120
     },
     {
         "test_name": "get_platform_ids",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "get_platform_ids"
+        "arguments": "get_platform_ids",
+        "time_limit": 120
     },
     {
         "test_name": "bool_type",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "bool_type"
+        "arguments": "bool_type",
+        "time_limit": 120
     },
     {
         "test_name": "repeated_setup_cleanup",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "repeated_setup_cleanup"
+        "arguments": "repeated_setup_cleanup",
+        "time_limit": 120
     },
     {
         "test_name": "retain_queue_single",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "retain_queue_single"
+        "arguments": "retain_queue_single",
+        "time_limit": 120
     },
     {
         "test_name": "retain_queue_multiple",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "retain_queue_multiple"
+        "arguments": "retain_queue_multiple",
+        "time_limit": 120
     },
     {
         "test_name": "retain_mem_object_single",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "retain_mem_object_single"
+        "arguments": "retain_mem_object_single",
+        "time_limit": 120
     },
     {
         "test_name": "retain_mem_object_multiple",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "retain_mem_object_multiple"
+        "arguments": "retain_mem_object_multiple",
+        "time_limit": 120
     },
     {
         "test_name": "retain_mem_object_set_kernel_arg",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "retain_mem_object_set_kernel_arg"
+        "arguments": "retain_mem_object_set_kernel_arg",
+        "time_limit": 120
     },
     {
         "test_name": "min_data_type_align_size_alignment",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "min_data_type_align_size_alignment"
+        "arguments": "min_data_type_align_size_alignment",
+        "time_limit": 120
     },
     {
         "test_name": "context_destructor_callback",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "context_destructor_callback"
+        "arguments": "context_destructor_callback",
+        "time_limit": 120
     },
     {
         "test_name": "mem_object_destructor_callback",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "mem_object_destructor_callback"
+        "arguments": "mem_object_destructor_callback",
+        "time_limit": 120
     },
     {
         "test_name": "null_buffer_arg",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "null_buffer_arg"
+        "arguments": "null_buffer_arg",
+        "time_limit": 120
     },
     {
         "test_name": "get_buffer_info",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "get_buffer_info"
+        "arguments": "get_buffer_info",
+        "time_limit": 120
     },
     {
         "test_name": "get_image2d_info",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "get_image2d_info"
+        "arguments": "get_image2d_info",
+        "time_limit": 120
     },
     {
         "test_name": "get_image3d_info",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "get_image3d_info"
+        "arguments": "get_image3d_info",
+        "time_limit": 120
     },
     {
         "test_name": "get_image1d_info",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "get_image1d_info"
+        "arguments": "get_image1d_info",
+        "time_limit": 120
     },
     {
         "test_name": "get_image1d_array_info",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "get_image1d_array_info"
+        "arguments": "get_image1d_array_info",
+        "time_limit": 120
     },
     {
         "test_name": "get_image2d_array_info",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "get_image2d_array_info"
+        "arguments": "get_image2d_array_info",
+        "time_limit": 120
     },
     {
         "test_name": "queue_flush_on_release",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "queue_flush_on_release"
+        "arguments": "queue_flush_on_release",
+        "time_limit": 120
     },
     {
         "test_name": "queue_hint",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "queue_hint"
+        "arguments": "queue_hint",
+        "time_limit": 120
     },
     {
         "test_name": "queue_properties",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "queue_properties"
+        "arguments": "queue_properties",
+        "time_limit": 120
     },
     {
         "test_name": "sub_group_dispatch",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "sub_group_dispatch"
+        "arguments": "sub_group_dispatch",
+        "time_limit": 120
     },
     {
         "test_name": "clone_kernel",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "clone_kernel"
+        "arguments": "clone_kernel",
+        "time_limit": 120
     },
     {
         "test_name": "zero_sized_enqueue",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "zero_sized_enqueue"
+        "arguments": "zero_sized_enqueue",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_properties_queries",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "buffer_properties_queries"
+        "arguments": "buffer_properties_queries",
+        "time_limit": 120
     },
     {
         "test_name": "image_properties_queries",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "image_properties_queries"
+        "arguments": "image_properties_queries",
+        "time_limit": 120
     },
     {
         "test_name": "queue_properties_queries",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "queue_properties_queries"
+        "arguments": "queue_properties_queries",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_properties_queries",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "pipe_properties_queries"
+        "arguments": "pipe_properties_queries",
+        "time_limit": 120
     },
     {
         "test_name": "consistency_svm",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "consistency_svm"
+        "arguments": "consistency_svm",
+        "time_limit": 120
     },
     {
         "test_name": "consistency_memory_model",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "consistency_memory_model"
+        "arguments": "consistency_memory_model",
+        "time_limit": 120
     },
     {
         "test_name": "consistency_device_enqueue",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "consistency_device_enqueue"
+        "arguments": "consistency_device_enqueue",
+        "time_limit": 120
     },
     {
         "test_name": "consistency_pipes",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "consistency_pipes"
+        "arguments": "consistency_pipes",
+        "time_limit": 120
     },
     {
         "test_name": "consistency_progvar",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "consistency_progvar"
+        "arguments": "consistency_progvar",
+        "time_limit": 120
     },
     {
         "test_name": "consistency_non_uniform_work_group",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "consistency_non_uniform_work_group"
+        "arguments": "consistency_non_uniform_work_group",
+        "time_limit": 120
     },
     {
         "test_name": "consistency_read_write_images",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "consistency_read_write_images"
+        "arguments": "consistency_read_write_images",
+        "time_limit": 120
     },
     {
         "test_name": "consistency_2d_image_from_buffer",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "consistency_2d_image_from_buffer"
+        "arguments": "consistency_2d_image_from_buffer",
+        "time_limit": 120
     },
     {
         "test_name": "consistency_depth_images",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "consistency_depth_images"
+        "arguments": "consistency_depth_images",
+        "time_limit": 120
     },
     {
         "test_name": "consistency_device_and_host_timer",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "consistency_device_and_host_timer"
+        "arguments": "consistency_device_and_host_timer",
+        "time_limit": 120
     },
     {
         "test_name": "consistency_il_programs",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "consistency_il_programs"
+        "arguments": "consistency_il_programs",
+        "time_limit": 120
     },
     {
         "test_name": "consistency_subgroups",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "consistency_subgroups"
+        "arguments": "consistency_subgroups",
+        "time_limit": 120
     },
     {
         "test_name": "consistency_prog_ctor_dtor",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "consistency_prog_ctor_dtor"
+        "arguments": "consistency_prog_ctor_dtor",
+        "time_limit": 120
     },
     {
         "test_name": "consistency_3d_image_writes",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "consistency_3d_image_writes"
+        "arguments": "consistency_3d_image_writes",
+        "time_limit": 120
     },
     {
         "test_name": "min_image_formats",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "min_image_formats"
+        "arguments": "min_image_formats",
+        "time_limit": 120
     },
     {
         "test_name": "negative_get_platform_info",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "negative_get_platform_info"
+        "arguments": "negative_get_platform_info",
+        "time_limit": 120
     },
     {
         "test_name": "negative_get_platform_ids",
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
-        "arguments": "negative_get_platform_ids"
+        "arguments": "negative_get_platform_ids",
+        "time_limit": 120
     },
     {
         "test_name": "hostptr",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "hostptr"
+        "arguments": "hostptr",
+        "time_limit": 120
     },
     {
         "test_name": "fpmath_float",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "fpmath_float"
+        "arguments": "fpmath_float",
+        "time_limit": 120
     },
     {
         "test_name": "fpmath_float2",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "fpmath_float2"
+        "arguments": "fpmath_float2",
+        "time_limit": 120
     },
     {
         "test_name": "fpmath_float4",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "fpmath_float4"
+        "arguments": "fpmath_float4",
+        "time_limit": 120
     },
     {
         "test_name": "intmath_int",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "intmath_int"
+        "arguments": "intmath_int",
+        "time_limit": 120
     },
     {
         "test_name": "intmath_int2",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "intmath_int2"
+        "arguments": "intmath_int2",
+        "time_limit": 120
     },
     {
         "test_name": "intmath_int4",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "intmath_int4"
+        "arguments": "intmath_int4",
+        "time_limit": 120
     },
     {
         "test_name": "intmath_long",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "intmath_long"
+        "arguments": "intmath_long",
+        "time_limit": 120
     },
     {
         "test_name": "intmath_long2",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "intmath_long2"
+        "arguments": "intmath_long2",
+        "time_limit": 120
     },
     {
         "test_name": "intmath_long4",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "intmath_long4"
+        "arguments": "intmath_long4",
+        "time_limit": 120
     },
     {
         "test_name": "hiloeo",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "hiloeo"
+        "arguments": "hiloeo",
+        "time_limit": 120
     },
     {
         "test_name": "if",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "if"
+        "arguments": "if",
+        "time_limit": 120
     },
     {
         "test_name": "sizeof",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "sizeof"
+        "arguments": "sizeof",
+        "time_limit": 120
     },
     {
         "test_name": "loop",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "loop"
+        "arguments": "loop",
+        "time_limit": 120
     },
     {
         "test_name": "pointer_cast",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "pointer_cast"
+        "arguments": "pointer_cast",
+        "time_limit": 120
     },
     {
         "test_name": "local_arg_def",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "local_arg_def"
+        "arguments": "local_arg_def",
+        "time_limit": 120
     },
     {
         "test_name": "local_kernel_def",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "local_kernel_def"
+        "arguments": "local_kernel_def",
+        "time_limit": 120
     },
     {
         "test_name": "local_kernel_scope",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "local_kernel_scope"
+        "arguments": "local_kernel_scope",
+        "time_limit": 120
     },
     {
         "test_name": "constant",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "constant"
+        "arguments": "constant",
+        "time_limit": 120
     },
     {
         "test_name": "constant_source",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "constant_source"
+        "arguments": "constant_source",
+        "time_limit": 120
     },
     {
         "test_name": "readimage",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "readimage"
+        "arguments": "readimage",
+        "time_limit": 120
     },
     {
         "test_name": "readimage_int16",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "readimage_int16"
+        "arguments": "readimage_int16",
+        "time_limit": 120
     },
     {
         "test_name": "readimage_fp32",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "readimage_fp32"
+        "arguments": "readimage_fp32",
+        "time_limit": 120
     },
     {
         "test_name": "writeimage",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "writeimage"
+        "arguments": "writeimage",
+        "time_limit": 120
     },
     {
         "test_name": "writeimage_int16",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "writeimage_int16"
+        "arguments": "writeimage_int16",
+        "time_limit": 120
     },
     {
         "test_name": "writeimage_fp32",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "writeimage_fp32"
+        "arguments": "writeimage_fp32",
+        "time_limit": 120
     },
     {
         "test_name": "mri_one",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "mri_one"
+        "arguments": "mri_one",
+        "time_limit": 120
     },
     {
         "test_name": "mri_multiple",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "mri_multiple"
+        "arguments": "mri_multiple",
+        "time_limit": 120
     },
     {
         "test_name": "image_r8",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "image_r8"
+        "arguments": "image_r8",
+        "time_limit": 120
     },
     {
         "test_name": "barrier",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "barrier"
+        "arguments": "barrier",
+        "time_limit": 120
     },
     {
         "test_name": "wg_barrier",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "wg_barrier"
+        "arguments": "wg_barrier",
+        "time_limit": 120
     },
     {
         "test_name": "int2float",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "int2float"
+        "arguments": "int2float",
+        "time_limit": 120
     },
     {
         "test_name": "float2int",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "float2int"
+        "arguments": "float2int",
+        "time_limit": 120
     },
     {
         "test_name": "imagereadwrite",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "imagereadwrite"
+        "arguments": "imagereadwrite",
+        "time_limit": 120
     },
     {
         "test_name": "imagereadwrite3d",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "imagereadwrite3d"
+        "arguments": "imagereadwrite3d",
+        "time_limit": 120
     },
     {
         "test_name": "readimage3d",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "readimage3d"
+        "arguments": "readimage3d",
+        "time_limit": 120
     },
     {
         "test_name": "readimage3d_int16",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "readimage3d_int16"
+        "arguments": "readimage3d_int16",
+        "time_limit": 120
     },
     {
         "test_name": "readimage3d_fp32",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "readimage3d_fp32"
+        "arguments": "readimage3d_fp32",
+        "time_limit": 120
     },
     {
         "test_name": "bufferreadwriterect",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "bufferreadwriterect"
+        "arguments": "bufferreadwriterect",
+        "time_limit": 120
     },
     {
         "test_name": "arrayreadwrite",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "arrayreadwrite"
+        "arguments": "arrayreadwrite",
+        "time_limit": 120
     },
     {
         "test_name": "arraycopy",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "arraycopy"
+        "arguments": "arraycopy",
+        "time_limit": 120
     },
     {
         "test_name": "imagearraycopy",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "imagearraycopy"
+        "arguments": "imagearraycopy",
+        "time_limit": 120
     },
     {
         "test_name": "imagearraycopy3d",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "imagearraycopy3d"
+        "arguments": "imagearraycopy3d",
+        "time_limit": 120
     },
     {
         "test_name": "imagecopy",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "imagecopy"
+        "arguments": "imagecopy",
+        "time_limit": 120
     },
     {
         "test_name": "imagecopy3d",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "imagecopy3d"
+        "arguments": "imagecopy3d",
+        "time_limit": 120
     },
     {
         "test_name": "imagerandomcopy",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "imagerandomcopy"
+        "arguments": "imagerandomcopy",
+        "time_limit": 120
     },
     {
         "test_name": "arrayimagecopy",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "arrayimagecopy"
+        "arguments": "arrayimagecopy",
+        "time_limit": 120
     },
     {
         "test_name": "arrayimagecopy3d",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "arrayimagecopy3d"
+        "arguments": "arrayimagecopy3d",
+        "time_limit": 120
     },
     {
         "test_name": "imagenpot",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "imagenpot"
+        "arguments": "imagenpot",
+        "time_limit": 120
     },
     {
         "test_name": "vload_global",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "vload_global"
+        "arguments": "vload_global",
+        "time_limit": 120
     },
     {
         "test_name": "vload_local",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "vload_local"
+        "arguments": "vload_local",
+        "time_limit": 120
     },
     {
         "test_name": "vload_constant",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "vload_constant"
+        "arguments": "vload_constant",
+        "time_limit": 120
     },
     {
         "test_name": "vload_private",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "vload_private"
+        "arguments": "vload_private",
+        "time_limit": 120
     },
     {
         "test_name": "vstore_global",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "vstore_global"
+        "arguments": "vstore_global",
+        "time_limit": 120
     },
     {
         "test_name": "vstore_local",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "vstore_local"
+        "arguments": "vstore_local",
+        "time_limit": 120
     },
     {
         "test_name": "vstore_private",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "vstore_private"
+        "arguments": "vstore_private",
+        "time_limit": 120
     },
     {
         "test_name": "createkernelsinprogram",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "createkernelsinprogram"
+        "arguments": "createkernelsinprogram",
+        "time_limit": 120
     },
     {
         "test_name": "imagedim_pow2",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "imagedim_pow2"
+        "arguments": "imagedim_pow2",
+        "time_limit": 120
     },
     {
         "test_name": "imagedim_non_pow2",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "imagedim_non_pow2"
+        "arguments": "imagedim_non_pow2",
+        "time_limit": 120
     },
     {
         "test_name": "image_param",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "image_param"
+        "arguments": "image_param",
+        "time_limit": 120
     },
     {
         "test_name": "image_multipass_integer_coord",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "image_multipass_integer_coord"
+        "arguments": "image_multipass_integer_coord",
+        "time_limit": 120
     },
     {
         "test_name": "image_multipass_float_coord",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "image_multipass_float_coord"
+        "arguments": "image_multipass_float_coord",
+        "time_limit": 120
     },
     {
         "test_name": "explicit_s2v_char",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "explicit_s2v_char"
+        "arguments": "explicit_s2v_char",
+        "time_limit": 120
     },
     {
         "test_name": "explicit_s2v_uchar",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "explicit_s2v_uchar"
+        "arguments": "explicit_s2v_uchar",
+        "time_limit": 120
     },
     {
         "test_name": "explicit_s2v_short",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "explicit_s2v_short"
+        "arguments": "explicit_s2v_short",
+        "time_limit": 120
     },
     {
         "test_name": "explicit_s2v_ushort",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "explicit_s2v_ushort"
+        "arguments": "explicit_s2v_ushort",
+        "time_limit": 120
     },
     {
         "test_name": "explicit_s2v_int",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "explicit_s2v_int"
+        "arguments": "explicit_s2v_int",
+        "time_limit": 120
     },
     {
         "test_name": "explicit_s2v_uint",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "explicit_s2v_uint"
+        "arguments": "explicit_s2v_uint",
+        "time_limit": 120
     },
     {
         "test_name": "explicit_s2v_long",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "explicit_s2v_long"
+        "arguments": "explicit_s2v_long",
+        "time_limit": 120
     },
     {
         "test_name": "explicit_s2v_ulong",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "explicit_s2v_ulong"
+        "arguments": "explicit_s2v_ulong",
+        "time_limit": 120
     },
     {
         "test_name": "explicit_s2v_float",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "explicit_s2v_float"
+        "arguments": "explicit_s2v_float",
+        "time_limit": 120
     },
     {
         "test_name": "explicit_s2v_double",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "explicit_s2v_double"
+        "arguments": "explicit_s2v_double",
+        "time_limit": 120
     },
     {
         "test_name": "enqueue_map_buffer",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "enqueue_map_buffer"
+        "arguments": "enqueue_map_buffer",
+        "time_limit": 120
     },
     {
         "test_name": "enqueue_map_image",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "enqueue_map_image"
+        "arguments": "enqueue_map_image",
+        "time_limit": 120
     },
     {
         "test_name": "work_item_functions",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "work_item_functions"
+        "arguments": "work_item_functions",
+        "time_limit": 120
     },
     {
         "test_name": "astype",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "astype"
+        "arguments": "astype",
+        "time_limit": 120
     },
     {
         "test_name": "async_copy_global_to_local",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "async_copy_global_to_local"
+        "arguments": "async_copy_global_to_local",
+        "time_limit": 120
     },
     {
         "test_name": "async_copy_local_to_global",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "async_copy_local_to_global"
+        "arguments": "async_copy_local_to_global",
+        "time_limit": 120
     },
     {
         "test_name": "async_strided_copy_global_to_local",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "async_strided_copy_global_to_local"
+        "arguments": "async_strided_copy_global_to_local",
+        "time_limit": 120
     },
     {
         "test_name": "async_strided_copy_local_to_global",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "async_strided_copy_local_to_global"
+        "arguments": "async_strided_copy_local_to_global",
+        "time_limit": 120
     },
     {
         "test_name": "async_copy_global_to_local2D",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "async_copy_global_to_local2D"
+        "arguments": "async_copy_global_to_local2D",
+        "time_limit": 120
     },
     {
         "test_name": "async_copy_local_to_global2D",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "async_copy_local_to_global2D"
+        "arguments": "async_copy_local_to_global2D",
+        "time_limit": 120
     },
     {
         "test_name": "async_copy_global_to_local3D",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "async_copy_global_to_local3D"
+        "arguments": "async_copy_global_to_local3D",
+        "time_limit": 120
     },
     {
         "test_name": "async_copy_local_to_global3D",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "async_copy_local_to_global3D"
+        "arguments": "async_copy_local_to_global3D",
+        "time_limit": 120
     },
     {
         "test_name": "async_work_group_copy_fence_import_after_export_aliased_local",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "async_work_group_copy_fence_import_after_export_aliased_local"
+        "arguments": "async_work_group_copy_fence_import_after_export_aliased_local",
+        "time_limit": 120
     },
     {
         "test_name": "async_work_group_copy_fence_import_after_export_aliased_global",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "async_work_group_copy_fence_import_after_export_aliased_global"
+        "arguments": "async_work_group_copy_fence_import_after_export_aliased_global",
+        "time_limit": 120
     },
     {
         "test_name": "async_work_group_copy_fence_import_after_export_aliased_global_and_local",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "async_work_group_copy_fence_import_after_export_aliased_global_and_local"
+        "arguments": "async_work_group_copy_fence_import_after_export_aliased_global_and_local",
+        "time_limit": 120
     },
     {
         "test_name": "async_work_group_copy_fence_export_after_import_aliased_local",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "async_work_group_copy_fence_export_after_import_aliased_local"
+        "arguments": "async_work_group_copy_fence_export_after_import_aliased_local",
+        "time_limit": 120
     },
     {
         "test_name": "async_work_group_copy_fence_export_after_import_aliased_global",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "async_work_group_copy_fence_export_after_import_aliased_global"
+        "arguments": "async_work_group_copy_fence_export_after_import_aliased_global",
+        "time_limit": 120
     },
     {
         "test_name": "async_work_group_copy_fence_export_after_import_aliased_global_and_local",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "async_work_group_copy_fence_export_after_import_aliased_global_and_local"
+        "arguments": "async_work_group_copy_fence_export_after_import_aliased_global_and_local",
+        "time_limit": 120
     },
     {
         "test_name": "prefetch",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "prefetch"
+        "arguments": "prefetch",
+        "time_limit": 120
     },
     {
         "test_name": "kernel_call_kernel_function",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "kernel_call_kernel_function"
+        "arguments": "kernel_call_kernel_function",
+        "time_limit": 120
     },
     {
         "test_name": "host_numeric_constants",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "host_numeric_constants"
+        "arguments": "host_numeric_constants",
+        "time_limit": 120
     },
     {
         "test_name": "kernel_numeric_constants",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "kernel_numeric_constants"
+        "arguments": "kernel_numeric_constants",
+        "time_limit": 120
     },
     {
         "test_name": "kernel_limit_constants",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "kernel_limit_constants"
+        "arguments": "kernel_limit_constants",
+        "time_limit": 120
     },
     {
         "test_name": "kernel_preprocessor_macros",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "kernel_preprocessor_macros"
+        "arguments": "kernel_preprocessor_macros",
+        "time_limit": 120
     },
     {
         "test_name": "parameter_types",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "parameter_types"
+        "arguments": "parameter_types",
+        "time_limit": 120
     },
     {
         "test_name": "vector_creation",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "vector_creation"
+        "arguments": "vector_creation",
+        "time_limit": 120
     },
     {
         "test_name": "vector_swizzle",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "vector_swizzle"
+        "arguments": "vector_swizzle",
+        "time_limit": 120
     },
     {
         "test_name": "vec_type_hint",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "vec_type_hint"
+        "arguments": "vec_type_hint",
+        "time_limit": 120
     },
     {
         "test_name": "kernel_memory_alignment_local",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "kernel_memory_alignment_local"
+        "arguments": "kernel_memory_alignment_local",
+        "time_limit": 120
     },
     {
         "test_name": "kernel_memory_alignment_global",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "kernel_memory_alignment_global"
+        "arguments": "kernel_memory_alignment_global",
+        "time_limit": 120
     },
     {
         "test_name": "kernel_memory_alignment_constant",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "kernel_memory_alignment_constant"
+        "arguments": "kernel_memory_alignment_constant",
+        "time_limit": 120
     },
     {
         "test_name": "kernel_memory_alignment_private",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "kernel_memory_alignment_private"
+        "arguments": "kernel_memory_alignment_private",
+        "time_limit": 120
     },
     {
         "test_name": "progvar_prog_scope_misc",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "progvar_prog_scope_misc"
+        "arguments": "progvar_prog_scope_misc",
+        "time_limit": 120
     },
     {
         "test_name": "progvar_prog_scope_uninit",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "progvar_prog_scope_uninit"
+        "arguments": "progvar_prog_scope_uninit",
+        "time_limit": 120
     },
     {
         "test_name": "progvar_prog_scope_init",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "progvar_prog_scope_init"
+        "arguments": "progvar_prog_scope_init",
+        "time_limit": 120
     },
     {
         "test_name": "progvar_func_scope",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "progvar_func_scope"
+        "arguments": "progvar_func_scope",
+        "time_limit": 120
     },
     {
         "test_name": "global_work_offsets",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "global_work_offsets"
+        "arguments": "global_work_offsets",
+        "time_limit": 120
     },
     {
         "test_name": "get_global_offset",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "get_global_offset"
+        "arguments": "get_global_offset",
+        "time_limit": 120
     },
     {
         "test_name": "global_linear_id",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "global_linear_id"
+        "arguments": "global_linear_id",
+        "time_limit": 120
     },
     {
         "test_name": "local_linear_id",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "local_linear_id"
+        "arguments": "local_linear_id",
+        "time_limit": 120
     },
     {
         "test_name": "enqueued_local_size",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "enqueued_local_size"
+        "arguments": "enqueued_local_size",
+        "time_limit": 120
     },
     {
         "test_name": "simple_read_image_pitch",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "simple_read_image_pitch"
+        "arguments": "simple_read_image_pitch",
+        "time_limit": 120
     },
     {
         "test_name": "simple_write_image_pitch",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "simple_write_image_pitch"
+        "arguments": "simple_write_image_pitch",
+        "time_limit": 120
     },
     {
         "test_name": "get_linear_ids",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "get_linear_ids"
+        "arguments": "get_linear_ids",
+        "time_limit": 120
     },
     {
         "test_name": "rw_image_access_qualifier",
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
-        "arguments": "rw_image_access_qualifier"
+        "arguments": "rw_image_access_qualifier",
+        "time_limit": 120
     },
     {
         "test_name": "atomic_add",
         "test_category": "atomics",
         "executable_path": "test_conformance/atomics/bin/test_atomics",
-        "arguments": "atomic_add"
+        "arguments": "atomic_add",
+        "time_limit": 120
     },
     {
         "test_name": "atomic_sub",
         "test_category": "atomics",
         "executable_path": "test_conformance/atomics/bin/test_atomics",
-        "arguments": "atomic_sub"
+        "arguments": "atomic_sub",
+        "time_limit": 120
     },
     {
         "test_name": "atomic_xchg",
         "test_category": "atomics",
         "executable_path": "test_conformance/atomics/bin/test_atomics",
-        "arguments": "atomic_xchg"
+        "arguments": "atomic_xchg",
+        "time_limit": 120
     },
     {
         "test_name": "atomic_min",
         "test_category": "atomics",
         "executable_path": "test_conformance/atomics/bin/test_atomics",
-        "arguments": "atomic_min"
+        "arguments": "atomic_min",
+        "time_limit": 120
     },
     {
         "test_name": "atomic_max",
         "test_category": "atomics",
         "executable_path": "test_conformance/atomics/bin/test_atomics",
-        "arguments": "atomic_max"
+        "arguments": "atomic_max",
+        "time_limit": 120
     },
     {
         "test_name": "atomic_inc",
         "test_category": "atomics",
         "executable_path": "test_conformance/atomics/bin/test_atomics",
-        "arguments": "atomic_inc"
+        "arguments": "atomic_inc",
+        "time_limit": 120
     },
     {
         "test_name": "atomic_dec",
         "test_category": "atomics",
         "executable_path": "test_conformance/atomics/bin/test_atomics",
-        "arguments": "atomic_dec"
+        "arguments": "atomic_dec",
+        "time_limit": 120
     },
     {
         "test_name": "atomic_cmpxchg",
         "test_category": "atomics",
         "executable_path": "test_conformance/atomics/bin/test_atomics",
-        "arguments": "atomic_cmpxchg"
+        "arguments": "atomic_cmpxchg",
+        "time_limit": 120
     },
     {
         "test_name": "atomic_and",
         "test_category": "atomics",
         "executable_path": "test_conformance/atomics/bin/test_atomics",
-        "arguments": "atomic_and"
+        "arguments": "atomic_and",
+        "time_limit": 120
     },
     {
         "test_name": "atomic_or",
         "test_category": "atomics",
         "executable_path": "test_conformance/atomics/bin/test_atomics",
-        "arguments": "atomic_or"
+        "arguments": "atomic_or",
+        "time_limit": 120
     },
     {
         "test_name": "atomic_xor",
         "test_category": "atomics",
         "executable_path": "test_conformance/atomics/bin/test_atomics",
-        "arguments": "atomic_xor"
+        "arguments": "atomic_xor",
+        "time_limit": 120
     },
     {
         "test_name": "atomic_add_index",
         "test_category": "atomics",
         "executable_path": "test_conformance/atomics/bin/test_atomics",
-        "arguments": "atomic_add_index"
+        "arguments": "atomic_add_index",
+        "time_limit": 120
     },
     {
         "test_name": "atomic_add_index_bin",
         "test_category": "atomics",
         "executable_path": "test_conformance/atomics/bin/test_atomics",
-        "arguments": "atomic_add_index_bin"
+        "arguments": "atomic_add_index_bin",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_read_async_int",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_read_async_int"
+        "arguments": "buffer_read_async_int",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_read_async_uint",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_read_async_uint"
+        "arguments": "buffer_read_async_uint",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_read_async_long",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_read_async_long"
+        "arguments": "buffer_read_async_long",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_read_async_ulong",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_read_async_ulong"
+        "arguments": "buffer_read_async_ulong",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_read_async_short",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_read_async_short"
+        "arguments": "buffer_read_async_short",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_read_async_ushort",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_read_async_ushort"
+        "arguments": "buffer_read_async_ushort",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_read_async_char",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_read_async_char"
+        "arguments": "buffer_read_async_char",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_read_async_uchar",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_read_async_uchar"
+        "arguments": "buffer_read_async_uchar",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_read_async_float",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_read_async_float"
+        "arguments": "buffer_read_async_float",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_read_array_barrier_int",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_read_array_barrier_int"
+        "arguments": "buffer_read_array_barrier_int",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_read_array_barrier_uint",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_read_array_barrier_uint"
+        "arguments": "buffer_read_array_barrier_uint",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_read_array_barrier_long",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_read_array_barrier_long"
+        "arguments": "buffer_read_array_barrier_long",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_read_array_barrier_ulong",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_read_array_barrier_ulong"
+        "arguments": "buffer_read_array_barrier_ulong",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_read_array_barrier_short",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_read_array_barrier_short"
+        "arguments": "buffer_read_array_barrier_short",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_read_array_barrier_ushort",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_read_array_barrier_ushort"
+        "arguments": "buffer_read_array_barrier_ushort",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_read_array_barrier_char",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_read_array_barrier_char"
+        "arguments": "buffer_read_array_barrier_char",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_read_array_barrier_uchar",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_read_array_barrier_uchar"
+        "arguments": "buffer_read_array_barrier_uchar",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_read_array_barrier_float",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_read_array_barrier_float"
+        "arguments": "buffer_read_array_barrier_float",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_read_int",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_read_int"
+        "arguments": "buffer_read_int",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_read_uint",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_read_uint"
+        "arguments": "buffer_read_uint",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_read_long",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_read_long"
+        "arguments": "buffer_read_long",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_read_ulong",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_read_ulong"
+        "arguments": "buffer_read_ulong",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_read_short",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_read_short"
+        "arguments": "buffer_read_short",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_read_ushort",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_read_ushort"
+        "arguments": "buffer_read_ushort",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_read_float",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_read_float"
+        "arguments": "buffer_read_float",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_read_half",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_read_half"
+        "arguments": "buffer_read_half",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_read_char",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_read_char"
+        "arguments": "buffer_read_char",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_read_uchar",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_read_uchar"
+        "arguments": "buffer_read_uchar",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_read_struct",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_read_struct"
+        "arguments": "buffer_read_struct",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_read_random_size",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_read_random_size"
+        "arguments": "buffer_read_random_size",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_map_read_int",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_map_read_int"
+        "arguments": "buffer_map_read_int",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_map_read_uint",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_map_read_uint"
+        "arguments": "buffer_map_read_uint",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_map_read_long",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_map_read_long"
+        "arguments": "buffer_map_read_long",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_map_read_ulong",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_map_read_ulong"
+        "arguments": "buffer_map_read_ulong",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_map_read_short",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_map_read_short"
+        "arguments": "buffer_map_read_short",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_map_read_ushort",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_map_read_ushort"
+        "arguments": "buffer_map_read_ushort",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_map_read_char",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_map_read_char"
+        "arguments": "buffer_map_read_char",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_map_read_uchar",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_map_read_uchar"
+        "arguments": "buffer_map_read_uchar",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_map_read_float",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_map_read_float"
+        "arguments": "buffer_map_read_float",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_map_read_struct",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_map_read_struct"
+        "arguments": "buffer_map_read_struct",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_map_write_int",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_map_write_int"
+        "arguments": "buffer_map_write_int",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_map_write_uint",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_map_write_uint"
+        "arguments": "buffer_map_write_uint",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_map_write_long",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_map_write_long"
+        "arguments": "buffer_map_write_long",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_map_write_ulong",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_map_write_ulong"
+        "arguments": "buffer_map_write_ulong",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_map_write_short",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_map_write_short"
+        "arguments": "buffer_map_write_short",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_map_write_ushort",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_map_write_ushort"
+        "arguments": "buffer_map_write_ushort",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_map_write_char",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_map_write_char"
+        "arguments": "buffer_map_write_char",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_map_write_uchar",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_map_write_uchar"
+        "arguments": "buffer_map_write_uchar",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_map_write_float",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_map_write_float"
+        "arguments": "buffer_map_write_float",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_map_write_struct",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_map_write_struct"
+        "arguments": "buffer_map_write_struct",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_write_int",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_write_int"
+        "arguments": "buffer_write_int",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_write_uint",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_write_uint"
+        "arguments": "buffer_write_uint",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_write_short",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_write_short"
+        "arguments": "buffer_write_short",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_write_ushort",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_write_ushort"
+        "arguments": "buffer_write_ushort",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_write_char",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_write_char"
+        "arguments": "buffer_write_char",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_write_uchar",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_write_uchar"
+        "arguments": "buffer_write_uchar",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_write_float",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_write_float"
+        "arguments": "buffer_write_float",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_write_half",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_write_half"
+        "arguments": "buffer_write_half",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_write_long",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_write_long"
+        "arguments": "buffer_write_long",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_write_ulong",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_write_ulong"
+        "arguments": "buffer_write_ulong",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_write_struct",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_write_struct"
+        "arguments": "buffer_write_struct",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_write_async_int",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_write_async_int"
+        "arguments": "buffer_write_async_int",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_write_async_uint",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_write_async_uint"
+        "arguments": "buffer_write_async_uint",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_write_async_short",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_write_async_short"
+        "arguments": "buffer_write_async_short",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_write_async_ushort",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_write_async_ushort"
+        "arguments": "buffer_write_async_ushort",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_write_async_char",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_write_async_char"
+        "arguments": "buffer_write_async_char",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_write_async_uchar",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_write_async_uchar"
+        "arguments": "buffer_write_async_uchar",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_write_async_float",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_write_async_float"
+        "arguments": "buffer_write_async_float",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_write_async_long",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_write_async_long"
+        "arguments": "buffer_write_async_long",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_write_async_ulong",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_write_async_ulong"
+        "arguments": "buffer_write_async_ulong",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_copy",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_copy"
+        "arguments": "buffer_copy",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_partial_copy",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_partial_copy"
+        "arguments": "buffer_partial_copy",
+        "time_limit": 120
     },
     {
         "test_name": "mem_read_write_flags",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "mem_read_write_flags"
+        "arguments": "mem_read_write_flags",
+        "time_limit": 120
     },
     {
         "test_name": "mem_write_only_flags",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "mem_write_only_flags"
+        "arguments": "mem_write_only_flags",
+        "time_limit": 120
     },
     {
         "test_name": "mem_read_only_flags",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "mem_read_only_flags"
+        "arguments": "mem_read_only_flags",
+        "time_limit": 120
     },
     {
         "test_name": "mem_copy_host_flags",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "mem_copy_host_flags"
+        "arguments": "mem_copy_host_flags",
+        "time_limit": 120
     },
     {
         "test_name": "mem_alloc_ref_flags",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "mem_alloc_ref_flags"
+        "arguments": "mem_alloc_ref_flags",
+        "time_limit": 120
     },
     {
         "test_name": "array_info_size",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "array_info_size"
+        "arguments": "array_info_size",
+        "time_limit": 120
     },
     {
         "test_name": "sub_buffers_read_write",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "sub_buffers_read_write"
+        "arguments": "sub_buffers_read_write",
+        "time_limit": 120
     },
     {
         "test_name": "sub_buffers_read_write_dual_devices",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "sub_buffers_read_write_dual_devices"
+        "arguments": "sub_buffers_read_write_dual_devices",
+        "time_limit": 120
     },
     {
         "test_name": "sub_buffers_overlapping",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "sub_buffers_overlapping"
+        "arguments": "sub_buffers_overlapping",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_fill_int",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_fill_int"
+        "arguments": "buffer_fill_int",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_fill_uint",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_fill_uint"
+        "arguments": "buffer_fill_uint",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_fill_short",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_fill_short"
+        "arguments": "buffer_fill_short",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_fill_ushort",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_fill_ushort"
+        "arguments": "buffer_fill_ushort",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_fill_char",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_fill_char"
+        "arguments": "buffer_fill_char",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_fill_uchar",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_fill_uchar"
+        "arguments": "buffer_fill_uchar",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_fill_long",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_fill_long"
+        "arguments": "buffer_fill_long",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_fill_ulong",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_fill_ulong"
+        "arguments": "buffer_fill_ulong",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_fill_float",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_fill_float"
+        "arguments": "buffer_fill_float",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_fill_struct",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_fill_struct"
+        "arguments": "buffer_fill_struct",
+        "time_limit": 120
     },
     {
         "test_name": "buffer_migrate",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "buffer_migrate"
+        "arguments": "buffer_migrate",
+        "time_limit": 120
     },
     {
         "test_name": "image_migrate",
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
-        "arguments": "image_migrate"
+        "arguments": "image_migrate",
+        "time_limit": 120
     },
     {
         "test_name": "clamp",
         "test_category": "commonfns",
         "executable_path": "test_conformance/commonfns/bin/test_commonfns",
-        "arguments": "clamp"
+        "arguments": "clamp",
+        "time_limit": 120
     },
     {
         "test_name": "degrees",
         "test_category": "commonfns",
         "executable_path": "test_conformance/commonfns/bin/test_commonfns",
-        "arguments": "degrees"
+        "arguments": "degrees",
+        "time_limit": 120
     },
     {
         "test_name": "fmax",
         "test_category": "commonfns",
         "executable_path": "test_conformance/commonfns/bin/test_commonfns",
-        "arguments": "fmax"
+        "arguments": "fmax",
+        "time_limit": 120
     },
     {
         "test_name": "fmaxf",
         "test_category": "commonfns",
         "executable_path": "test_conformance/commonfns/bin/test_commonfns",
-        "arguments": "fmaxf"
+        "arguments": "fmaxf",
+        "time_limit": 120
     },
     {
         "test_name": "fmin",
         "test_category": "commonfns",
         "executable_path": "test_conformance/commonfns/bin/test_commonfns",
-        "arguments": "fmin"
+        "arguments": "fmin",
+        "time_limit": 120
     },
     {
         "test_name": "fminf",
         "test_category": "commonfns",
         "executable_path": "test_conformance/commonfns/bin/test_commonfns",
-        "arguments": "fminf"
+        "arguments": "fminf",
+        "time_limit": 120
     },
     {
         "test_name": "max",
         "test_category": "commonfns",
         "executable_path": "test_conformance/commonfns/bin/test_commonfns",
-        "arguments": "max"
+        "arguments": "max",
+        "time_limit": 120
     },
     {
         "test_name": "maxf",
         "test_category": "commonfns",
         "executable_path": "test_conformance/commonfns/bin/test_commonfns",
-        "arguments": "maxf"
+        "arguments": "maxf",
+        "time_limit": 120
     },
     {
         "test_name": "min",
         "test_category": "commonfns",
         "executable_path": "test_conformance/commonfns/bin/test_commonfns",
-        "arguments": "min"
+        "arguments": "min",
+        "time_limit": 120
     },
     {
         "test_name": "minf",
         "test_category": "commonfns",
         "executable_path": "test_conformance/commonfns/bin/test_commonfns",
-        "arguments": "minf"
+        "arguments": "minf",
+        "time_limit": 120
     },
     {
         "test_name": "mix",
         "test_category": "commonfns",
         "executable_path": "test_conformance/commonfns/bin/test_commonfns",
-        "arguments": "mix"
+        "arguments": "mix",
+        "time_limit": 120
     },
     {
         "test_name": "radians",
         "test_category": "commonfns",
         "executable_path": "test_conformance/commonfns/bin/test_commonfns",
-        "arguments": "radians"
+        "arguments": "radians",
+        "time_limit": 120
     },
     {
         "test_name": "step",
         "test_category": "commonfns",
         "executable_path": "test_conformance/commonfns/bin/test_commonfns",
-        "arguments": "step"
+        "arguments": "step",
+        "time_limit": 120
     },
     {
         "test_name": "stepf",
         "test_category": "commonfns",
         "executable_path": "test_conformance/commonfns/bin/test_commonfns",
-        "arguments": "stepf"
+        "arguments": "stepf",
+        "time_limit": 120
     },
     {
         "test_name": "smoothstep",
         "test_category": "commonfns",
         "executable_path": "test_conformance/commonfns/bin/test_commonfns",
-        "arguments": "smoothstep"
+        "arguments": "smoothstep",
+        "time_limit": 120
     },
     {
         "test_name": "smoothstepf",
         "test_category": "commonfns",
         "executable_path": "test_conformance/commonfns/bin/test_commonfns",
-        "arguments": "smoothstepf"
+        "arguments": "smoothstepf",
+        "time_limit": 120
     },
     {
         "test_name": "sign",
         "test_category": "commonfns",
         "executable_path": "test_conformance/commonfns/bin/test_commonfns",
-        "arguments": "sign"
+        "arguments": "sign",
+        "time_limit": 120
     },
     {
         "test_name": "load_program_source",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "load_program_source"
+        "arguments": "load_program_source",
+        "time_limit": 120
     },
     {
         "test_name": "load_multistring_source",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "load_multistring_source"
+        "arguments": "load_multistring_source",
+        "time_limit": 120
     },
     {
         "test_name": "load_two_kernel_source",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "load_two_kernel_source"
+        "arguments": "load_two_kernel_source",
+        "time_limit": 120
     },
     {
         "test_name": "load_null_terminated_source",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "load_null_terminated_source"
+        "arguments": "load_null_terminated_source",
+        "time_limit": 120
     },
     {
         "test_name": "load_null_terminated_multi_line_source",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "load_null_terminated_multi_line_source"
+        "arguments": "load_null_terminated_multi_line_source",
+        "time_limit": 120
     },
     {
         "test_name": "load_null_terminated_partial_multi_line_source",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "load_null_terminated_partial_multi_line_source"
+        "arguments": "load_null_terminated_partial_multi_line_source",
+        "time_limit": 120
     },
     {
         "test_name": "load_discreet_length_source",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "load_discreet_length_source"
+        "arguments": "load_discreet_length_source",
+        "time_limit": 120
     },
     {
         "test_name": "get_program_source",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "get_program_source"
+        "arguments": "get_program_source",
+        "time_limit": 120
     },
     {
         "test_name": "get_program_build_info",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "get_program_build_info"
+        "arguments": "get_program_build_info",
+        "time_limit": 120
     },
     {
         "test_name": "get_program_info",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "get_program_info"
+        "arguments": "get_program_info",
+        "time_limit": 120
     },
     {
         "test_name": "large_compile",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "large_compile"
+        "arguments": "large_compile",
+        "time_limit": 120
     },
     {
         "test_name": "async_build",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "async_build"
+        "arguments": "async_build",
+        "time_limit": 120
     },
     {
         "test_name": "options_build_optimizations",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "options_build_optimizations"
+        "arguments": "options_build_optimizations",
+        "time_limit": 120
     },
     {
         "test_name": "options_build_macro",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "options_build_macro"
+        "arguments": "options_build_macro",
+        "time_limit": 120
     },
     {
         "test_name": "options_build_macro_existence",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "options_build_macro_existence"
+        "arguments": "options_build_macro_existence",
+        "time_limit": 120
     },
     {
         "test_name": "options_include_directory",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "options_include_directory"
+        "arguments": "options_include_directory",
+        "time_limit": 120
     },
     {
         "test_name": "options_denorm_cache",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "options_denorm_cache"
+        "arguments": "options_denorm_cache",
+        "time_limit": 120
     },
     {
         "test_name": "preprocessor_define_udef",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "preprocessor_define_udef"
+        "arguments": "preprocessor_define_udef",
+        "time_limit": 120
     },
     {
         "test_name": "preprocessor_include",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "preprocessor_include"
+        "arguments": "preprocessor_include",
+        "time_limit": 120
     },
     {
         "test_name": "preprocessor_line_error",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "preprocessor_line_error"
+        "arguments": "preprocessor_line_error",
+        "time_limit": 120
     },
     {
         "test_name": "preprocessor_pragma",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "preprocessor_pragma"
+        "arguments": "preprocessor_pragma",
+        "time_limit": 120
     },
     {
         "test_name": "opencl_c_versions",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "opencl_c_versions"
+        "arguments": "opencl_c_versions",
+        "time_limit": 120
     },
     {
         "test_name": "compiler_defines_for_extensions",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "compiler_defines_for_extensions"
+        "arguments": "compiler_defines_for_extensions",
+        "time_limit": 120
     },
     {
         "test_name": "image_macro",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "image_macro"
+        "arguments": "image_macro",
+        "time_limit": 120
     },
     {
         "test_name": "simple_compile_only",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "simple_compile_only"
+        "arguments": "simple_compile_only",
+        "time_limit": 120
     },
     {
         "test_name": "simple_static_compile_only",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "simple_static_compile_only"
+        "arguments": "simple_static_compile_only",
+        "time_limit": 120
     },
     {
         "test_name": "simple_extern_compile_only",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "simple_extern_compile_only"
+        "arguments": "simple_extern_compile_only",
+        "time_limit": 120
     },
     {
         "test_name": "simple_compile_with_callback",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "simple_compile_with_callback"
+        "arguments": "simple_compile_with_callback",
+        "time_limit": 120
     },
     {
         "test_name": "simple_embedded_header_compile",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "simple_embedded_header_compile"
+        "arguments": "simple_embedded_header_compile",
+        "time_limit": 120
     },
     {
         "test_name": "simple_link_only",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "simple_link_only"
+        "arguments": "simple_link_only",
+        "time_limit": 120
     },
     {
         "test_name": "two_file_regular_variable_access",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "two_file_regular_variable_access"
+        "arguments": "two_file_regular_variable_access",
+        "time_limit": 120
     },
     {
         "test_name": "two_file_regular_struct_access",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "two_file_regular_struct_access"
+        "arguments": "two_file_regular_struct_access",
+        "time_limit": 120
     },
     {
         "test_name": "two_file_regular_function_access",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "two_file_regular_function_access"
+        "arguments": "two_file_regular_function_access",
+        "time_limit": 120
     },
     {
         "test_name": "simple_link_with_callback",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "simple_link_with_callback"
+        "arguments": "simple_link_with_callback",
+        "time_limit": 120
     },
     {
         "test_name": "simple_embedded_header_link",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "simple_embedded_header_link"
+        "arguments": "simple_embedded_header_link",
+        "time_limit": 120
     },
     {
         "test_name": "execute_after_simple_compile_and_link",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "execute_after_simple_compile_and_link"
+        "arguments": "execute_after_simple_compile_and_link",
+        "time_limit": 120
     },
     {
         "test_name": "execute_after_simple_compile_and_link_no_device_info",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "execute_after_simple_compile_and_link_no_device_info"
+        "arguments": "execute_after_simple_compile_and_link_no_device_info",
+        "time_limit": 120
     },
     {
         "test_name": "execute_after_simple_compile_and_link_with_defines",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "execute_after_simple_compile_and_link_with_defines"
+        "arguments": "execute_after_simple_compile_and_link_with_defines",
+        "time_limit": 120
     },
     {
         "test_name": "execute_after_simple_compile_and_link_with_callbacks",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "execute_after_simple_compile_and_link_with_callbacks"
+        "arguments": "execute_after_simple_compile_and_link_with_callbacks",
+        "time_limit": 120
     },
     {
         "test_name": "execute_after_simple_library_with_link",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "execute_after_simple_library_with_link"
+        "arguments": "execute_after_simple_library_with_link",
+        "time_limit": 120
     },
     {
         "test_name": "execute_after_two_file_link",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "execute_after_two_file_link"
+        "arguments": "execute_after_two_file_link",
+        "time_limit": 120
     },
     {
         "test_name": "execute_after_embedded_header_link",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "execute_after_embedded_header_link"
+        "arguments": "execute_after_embedded_header_link",
+        "time_limit": 120
     },
     {
         "test_name": "execute_after_included_header_link",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "execute_after_included_header_link"
+        "arguments": "execute_after_included_header_link",
+        "time_limit": 120
     },
     {
         "test_name": "execute_after_serialize_reload_object",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "execute_after_serialize_reload_object"
+        "arguments": "execute_after_serialize_reload_object",
+        "time_limit": 120
     },
     {
         "test_name": "execute_after_serialize_reload_library",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "execute_after_serialize_reload_library"
+        "arguments": "execute_after_serialize_reload_library",
+        "time_limit": 120
     },
     {
         "test_name": "simple_library_only",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "simple_library_only"
+        "arguments": "simple_library_only",
+        "time_limit": 120
     },
     {
         "test_name": "simple_library_with_callback",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "simple_library_with_callback"
+        "arguments": "simple_library_with_callback",
+        "time_limit": 120
     },
     {
         "test_name": "simple_library_with_link",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "simple_library_with_link"
+        "arguments": "simple_library_with_link",
+        "time_limit": 120
     },
     {
         "test_name": "two_file_link",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "two_file_link"
+        "arguments": "two_file_link",
+        "time_limit": 120
     },
     {
         "test_name": "multi_file_libraries",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "multi_file_libraries"
+        "arguments": "multi_file_libraries",
+        "time_limit": 120
     },
     {
         "test_name": "multiple_files",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "multiple_files"
+        "arguments": "multiple_files",
+        "time_limit": 120
     },
     {
         "test_name": "multiple_libraries",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "multiple_libraries"
+        "arguments": "multiple_libraries",
+        "time_limit": 120
     },
     {
         "test_name": "multiple_files_multiple_libraries",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "multiple_files_multiple_libraries"
+        "arguments": "multiple_files_multiple_libraries",
+        "time_limit": 120
     },
     {
         "test_name": "multiple_embedded_headers",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "multiple_embedded_headers"
+        "arguments": "multiple_embedded_headers",
+        "time_limit": 120
     },
     {
         "test_name": "program_binary_type",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "program_binary_type"
+        "arguments": "program_binary_type",
+        "time_limit": 120
     },
     {
         "test_name": "compile_and_link_status_options_log",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "compile_and_link_status_options_log"
+        "arguments": "compile_and_link_status_options_log",
+        "time_limit": 120
     },
     {
         "test_name": "pragma_unroll",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "pragma_unroll"
+        "arguments": "pragma_unroll",
+        "time_limit": 120
     },
     {
         "test_name": "features_macro",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "features_macro"
+        "arguments": "features_macro",
+        "time_limit": 120
     },
     {
         "test_name": "unload_valid",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "unload_valid"
+        "arguments": "unload_valid",
+        "time_limit": 120
     },
     {
         "test_name": "unload_repeated",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "unload_repeated"
+        "arguments": "unload_repeated",
+        "time_limit": 120
     },
     {
         "test_name": "unload_compile_unload_link",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "unload_compile_unload_link"
+        "arguments": "unload_compile_unload_link",
+        "time_limit": 120
     },
     {
         "test_name": "unload_build_unload_create_kernel",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "unload_build_unload_create_kernel"
+        "arguments": "unload_build_unload_create_kernel",
+        "time_limit": 120
     },
     {
         "test_name": "unload_link_different",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "unload_link_different"
+        "arguments": "unload_link_different",
+        "time_limit": 120
     },
     {
         "test_name": "unload_build_threaded",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "unload_build_threaded"
+        "arguments": "unload_build_threaded",
+        "time_limit": 120
     },
     {
         "test_name": "unload_build_info",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "unload_build_info"
+        "arguments": "unload_build_info",
+        "time_limit": 120
     },
     {
         "test_name": "unload_program_binaries",
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
-        "arguments": "unload_program_binaries"
+        "arguments": "unload_program_binaries",
+        "time_limit": 120
     },
     {
         "test_name": "computeinfo",
         "test_category": "computeinfo",
         "executable_path": "test_conformance/computeinfo/bin/test_computeinfo",
-        "arguments": "computeinfo"
+        "arguments": "computeinfo",
+        "time_limit": 120
     },
     {
         "test_name": "extended_versioning",
         "test_category": "computeinfo",
         "executable_path": "test_conformance/computeinfo/bin/test_computeinfo",
-        "arguments": "extended_versioning"
+        "arguments": "extended_versioning",
+        "time_limit": 120
     },
     {
         "test_name": "device_uuid",
         "test_category": "computeinfo",
         "executable_path": "test_conformance/computeinfo/bin/test_computeinfo",
-        "arguments": "device_uuid"
+        "arguments": "device_uuid",
+        "time_limit": 120
     },
     {
         "test_name": "conformance_version",
         "test_category": "computeinfo",
         "executable_path": "test_conformance/computeinfo/bin/test_computeinfo",
-        "arguments": "conformance_version"
+        "arguments": "conformance_version",
+        "time_limit": 120
     },
     {
         "test_name": "contractions_float_0",
         "test_category": "contractions",
         "executable_path": "test_conformance/contractions/bin/test_contractions",
-        "arguments": "contractions_float_0"
+        "arguments": "contractions_float_0",
+        "time_limit": 120
     },
     {
         "test_name": "contractions_float_1",
         "test_category": "contractions",
         "executable_path": "test_conformance/contractions/bin/test_contractions",
-        "arguments": "contractions_float_1"
+        "arguments": "contractions_float_1",
+        "time_limit": 120
     },
     {
         "test_name": "contractions_float_2",
         "test_category": "contractions",
         "executable_path": "test_conformance/contractions/bin/test_contractions",
-        "arguments": "contractions_float_2"
+        "arguments": "contractions_float_2",
+        "time_limit": 120
     },
     {
         "test_name": "contractions_float_3",
         "test_category": "contractions",
         "executable_path": "test_conformance/contractions/bin/test_contractions",
-        "arguments": "contractions_float_3"
+        "arguments": "contractions_float_3",
+        "time_limit": 120
     },
     {
         "test_name": "contractions_float_4",
         "test_category": "contractions",
         "executable_path": "test_conformance/contractions/bin/test_contractions",
-        "arguments": "contractions_float_4"
+        "arguments": "contractions_float_4",
+        "time_limit": 120
     },
     {
         "test_name": "contractions_float_5",
         "test_category": "contractions",
         "executable_path": "test_conformance/contractions/bin/test_contractions",
-        "arguments": "contractions_float_5"
+        "arguments": "contractions_float_5",
+        "time_limit": 120
     },
     {
         "test_name": "contractions_float_6",
         "test_category": "contractions",
         "executable_path": "test_conformance/contractions/bin/test_contractions",
-        "arguments": "contractions_float_6"
+        "arguments": "contractions_float_6",
+        "time_limit": 120
     },
     {
         "test_name": "contractions_float_7",
         "test_category": "contractions",
         "executable_path": "test_conformance/contractions/bin/test_contractions",
-        "arguments": "contractions_float_7"
+        "arguments": "contractions_float_7",
+        "time_limit": 120
     },
     {
         "test_name": "contractions_double_0",
         "test_category": "contractions",
         "executable_path": "test_conformance/contractions/bin/test_contractions",
-        "arguments": "contractions_double_0"
+        "arguments": "contractions_double_0",
+        "time_limit": 120
     },
     {
         "test_name": "contractions_double_1",
         "test_category": "contractions",
         "executable_path": "test_conformance/contractions/bin/test_contractions",
-        "arguments": "contractions_double_1"
+        "arguments": "contractions_double_1",
+        "time_limit": 120
     },
     {
         "test_name": "contractions_double_2",
         "test_category": "contractions",
         "executable_path": "test_conformance/contractions/bin/test_contractions",
-        "arguments": "contractions_double_2"
+        "arguments": "contractions_double_2",
+        "time_limit": 120
     },
     {
         "test_name": "contractions_double_3",
         "test_category": "contractions",
         "executable_path": "test_conformance/contractions/bin/test_contractions",
-        "arguments": "contractions_double_3"
+        "arguments": "contractions_double_3",
+        "time_limit": 120
     },
     {
         "test_name": "contractions_double_4",
         "test_category": "contractions",
         "executable_path": "test_conformance/contractions/bin/test_contractions",
-        "arguments": "contractions_double_4"
+        "arguments": "contractions_double_4",
+        "time_limit": 120
     },
     {
         "test_name": "contractions_double_5",
         "test_category": "contractions",
         "executable_path": "test_conformance/contractions/bin/test_contractions",
-        "arguments": "contractions_double_5"
+        "arguments": "contractions_double_5",
+        "time_limit": 120
     },
     {
         "test_name": "contractions_double_6",
         "test_category": "contractions",
         "executable_path": "test_conformance/contractions/bin/test_contractions",
-        "arguments": "contractions_double_6"
+        "arguments": "contractions_double_6",
+        "time_limit": 120
     },
     {
         "test_name": "contractions_double_7",
         "test_category": "contractions",
         "executable_path": "test_conformance/contractions/bin/test_contractions",
-        "arguments": "contractions_double_7"
+        "arguments": "contractions_double_7",
+        "time_limit": 120
     },
     {
         "test_name": "partition_equally",
         "test_category": "device_partition",
         "executable_path": "test_conformance/device_partition/bin/test_device_partition",
-        "arguments": "partition_equally"
+        "arguments": "partition_equally",
+        "time_limit": 120
     },
     {
         "test_name": "partition_by_counts",
         "test_category": "device_partition",
         "executable_path": "test_conformance/device_partition/bin/test_device_partition",
-        "arguments": "partition_by_counts"
+        "arguments": "partition_by_counts",
+        "time_limit": 120
     },
     {
         "test_name": "partition_by_affinity_domain_numa",
         "test_category": "device_partition",
         "executable_path": "test_conformance/device_partition/bin/test_device_partition",
-        "arguments": "partition_by_affinity_domain_numa"
+        "arguments": "partition_by_affinity_domain_numa",
+        "time_limit": 120
     },
     {
         "test_name": "partition_by_affinity_domain_l4_cache",
         "test_category": "device_partition",
         "executable_path": "test_conformance/device_partition/bin/test_device_partition",
-        "arguments": "partition_by_affinity_domain_l4_cache"
+        "arguments": "partition_by_affinity_domain_l4_cache",
+        "time_limit": 120
     },
     {
         "test_name": "partition_by_affinity_domain_l3_cache",
         "test_category": "device_partition",
         "executable_path": "test_conformance/device_partition/bin/test_device_partition",
-        "arguments": "partition_by_affinity_domain_l3_cache"
+        "arguments": "partition_by_affinity_domain_l3_cache",
+        "time_limit": 120
     },
     {
         "test_name": "partition_by_affinity_domain_l2_cache",
         "test_category": "device_partition",
         "executable_path": "test_conformance/device_partition/bin/test_device_partition",
-        "arguments": "partition_by_affinity_domain_l2_cache"
+        "arguments": "partition_by_affinity_domain_l2_cache",
+        "time_limit": 120
     },
     {
         "test_name": "partition_by_affinity_domain_l1_cache",
         "test_category": "device_partition",
         "executable_path": "test_conformance/device_partition/bin/test_device_partition",
-        "arguments": "partition_by_affinity_domain_l1_cache"
+        "arguments": "partition_by_affinity_domain_l1_cache",
+        "time_limit": 120
     },
     {
         "test_name": "partition_by_affinity_domain_next_partitionable",
         "test_category": "device_partition",
         "executable_path": "test_conformance/device_partition/bin/test_device_partition",
-        "arguments": "partition_by_affinity_domain_next_partitionable"
+        "arguments": "partition_by_affinity_domain_next_partitionable",
+        "time_limit": 120
     },
     {
         "test_name": "partition_all",
         "test_category": "device_partition",
         "executable_path": "test_conformance/device_partition/bin/test_device_partition",
-        "arguments": "partition_all"
+        "arguments": "partition_all",
+        "time_limit": 120
     },
     {
         "test_name": "event_get_execute_status",
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
-        "arguments": "event_get_execute_status"
+        "arguments": "event_get_execute_status",
+        "time_limit": 120
     },
     {
         "test_name": "event_get_write_array_status",
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
-        "arguments": "event_get_write_array_status"
+        "arguments": "event_get_write_array_status",
+        "time_limit": 120
     },
     {
         "test_name": "event_get_read_array_status",
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
-        "arguments": "event_get_read_array_status"
+        "arguments": "event_get_read_array_status",
+        "time_limit": 120
     },
     {
         "test_name": "event_get_info",
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
-        "arguments": "event_get_info"
+        "arguments": "event_get_info",
+        "time_limit": 120
     },
     {
         "test_name": "event_wait_for_execute",
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
-        "arguments": "event_wait_for_execute"
+        "arguments": "event_wait_for_execute",
+        "time_limit": 120
     },
     {
         "test_name": "event_wait_for_array",
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
-        "arguments": "event_wait_for_array"
+        "arguments": "event_wait_for_array",
+        "time_limit": 120
     },
     {
         "test_name": "event_flush",
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
-        "arguments": "event_flush"
+        "arguments": "event_flush",
+        "time_limit": 120
     },
     {
         "test_name": "event_finish_execute",
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
-        "arguments": "event_finish_execute"
+        "arguments": "event_finish_execute",
+        "time_limit": 120
     },
     {
         "test_name": "event_finish_array",
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
-        "arguments": "event_finish_array"
+        "arguments": "event_finish_array",
+        "time_limit": 120
     },
     {
         "test_name": "event_release_before_done",
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
-        "arguments": "event_release_before_done"
+        "arguments": "event_release_before_done",
+        "time_limit": 120
     },
     {
         "test_name": "event_enqueue_marker",
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
-        "arguments": "event_enqueue_marker"
+        "arguments": "event_enqueue_marker",
+        "time_limit": 120
     },
     {
         "test_name": "event_enqueue_marker_with_event_list",
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
-        "arguments": "event_enqueue_marker_with_event_list"
+        "arguments": "event_enqueue_marker_with_event_list",
+        "time_limit": 120
     },
     {
         "test_name": "event_enqueue_barrier_with_event_list",
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
-        "arguments": "event_enqueue_barrier_with_event_list"
+        "arguments": "event_enqueue_barrier_with_event_list",
+        "time_limit": 120
     },
     {
         "test_name": "out_of_order_event_waitlist_single_queue",
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
-        "arguments": "out_of_order_event_waitlist_single_queue"
+        "arguments": "out_of_order_event_waitlist_single_queue",
+        "time_limit": 120
     },
     {
         "test_name": "out_of_order_event_waitlist_multi_queue",
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
-        "arguments": "out_of_order_event_waitlist_multi_queue"
+        "arguments": "out_of_order_event_waitlist_multi_queue",
+        "time_limit": 120
     },
     {
         "test_name": "out_of_order_event_waitlist_multi_queue_multi_device",
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
-        "arguments": "out_of_order_event_waitlist_multi_queue_multi_device"
+        "arguments": "out_of_order_event_waitlist_multi_queue_multi_device",
+        "time_limit": 120
     },
     {
         "test_name": "out_of_order_event_enqueue_wait_for_events_single_queue",
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
-        "arguments": "out_of_order_event_enqueue_wait_for_events_single_queue"
+        "arguments": "out_of_order_event_enqueue_wait_for_events_single_queue",
+        "time_limit": 120
     },
     {
         "test_name": "out_of_order_event_enqueue_wait_for_events_multi_queue",
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
-        "arguments": "out_of_order_event_enqueue_wait_for_events_multi_queue"
+        "arguments": "out_of_order_event_enqueue_wait_for_events_multi_queue",
+        "time_limit": 120
     },
     {
         "test_name": "out_of_order_event_enqueue_wait_for_events_multi_queue_multi_device",
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
-        "arguments": "out_of_order_event_enqueue_wait_for_events_multi_queue_multi_device"
+        "arguments": "out_of_order_event_enqueue_wait_for_events_multi_queue_multi_device",
+        "time_limit": 120
     },
     {
         "test_name": "out_of_order_event_enqueue_marker_single_queue",
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
-        "arguments": "out_of_order_event_enqueue_marker_single_queue"
+        "arguments": "out_of_order_event_enqueue_marker_single_queue",
+        "time_limit": 120
     },
     {
         "test_name": "out_of_order_event_enqueue_marker_multi_queue",
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
-        "arguments": "out_of_order_event_enqueue_marker_multi_queue"
+        "arguments": "out_of_order_event_enqueue_marker_multi_queue",
+        "time_limit": 120
     },
     {
         "test_name": "out_of_order_event_enqueue_marker_multi_queue_multi_device",
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
-        "arguments": "out_of_order_event_enqueue_marker_multi_queue_multi_device"
+        "arguments": "out_of_order_event_enqueue_marker_multi_queue_multi_device",
+        "time_limit": 120
     },
     {
         "test_name": "out_of_order_event_enqueue_barrier_single_queue",
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
-        "arguments": "out_of_order_event_enqueue_barrier_single_queue"
+        "arguments": "out_of_order_event_enqueue_barrier_single_queue",
+        "time_limit": 120
     },
     {
         "test_name": "waitlists",
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
-        "arguments": "waitlists"
+        "arguments": "waitlists",
+        "time_limit": 120
     },
     {
         "test_name": "userevents",
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
-        "arguments": "userevents"
+        "arguments": "userevents",
+        "time_limit": 120
     },
     {
         "test_name": "callbacks",
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
-        "arguments": "callbacks"
+        "arguments": "callbacks",
+        "time_limit": 120
     },
     {
         "test_name": "callbacks_simultaneous",
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
-        "arguments": "callbacks_simultaneous"
+        "arguments": "callbacks_simultaneous",
+        "time_limit": 120
     },
     {
         "test_name": "userevents_multithreaded",
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
-        "arguments": "userevents_multithreaded"
+        "arguments": "userevents_multithreaded",
+        "time_limit": 120
     },
     {
         "test_name": "geom_cross",
         "test_category": "geometrics",
         "executable_path": "test_conformance/geometrics/bin/test_geometrics",
-        "arguments": "geom_cross"
+        "arguments": "geom_cross",
+        "time_limit": 120
     },
     {
         "test_name": "geom_dot",
         "test_category": "geometrics",
         "executable_path": "test_conformance/geometrics/bin/test_geometrics",
-        "arguments": "geom_dot"
+        "arguments": "geom_dot",
+        "time_limit": 120
     },
     {
         "test_name": "geom_distance",
         "test_category": "geometrics",
         "executable_path": "test_conformance/geometrics/bin/test_geometrics",
-        "arguments": "geom_distance"
+        "arguments": "geom_distance",
+        "time_limit": 120
     },
     {
         "test_name": "geom_fast_distance",
         "test_category": "geometrics",
         "executable_path": "test_conformance/geometrics/bin/test_geometrics",
-        "arguments": "geom_fast_distance"
+        "arguments": "geom_fast_distance",
+        "time_limit": 120
     },
     {
         "test_name": "geom_length",
         "test_category": "geometrics",
         "executable_path": "test_conformance/geometrics/bin/test_geometrics",
-        "arguments": "geom_length"
+        "arguments": "geom_length",
+        "time_limit": 120
     },
     {
         "test_name": "geom_fast_length",
         "test_category": "geometrics",
         "executable_path": "test_conformance/geometrics/bin/test_geometrics",
-        "arguments": "geom_fast_length"
+        "arguments": "geom_fast_length",
+        "time_limit": 120
     },
     {
         "test_name": "geom_normalize",
         "test_category": "geometrics",
         "executable_path": "test_conformance/geometrics/bin/test_geometrics",
-        "arguments": "geom_normalize"
+        "arguments": "geom_normalize",
+        "time_limit": 120
     },
     {
         "test_name": "geom_fast_normalize",
         "test_category": "geometrics",
         "executable_path": "test_conformance/geometrics/bin/test_geometrics",
-        "arguments": "geom_fast_normalize"
+        "arguments": "geom_fast_normalize",
+        "time_limit": 120
     },
     {
         "test_name": "vload_half",
         "test_category": "half",
         "executable_path": "test_conformance/half/bin/test_half",
-        "arguments": "vload_half"
+        "arguments": "vload_half",
+        "time_limit": 120
     },
     {
         "test_name": "vloada_half",
         "test_category": "half",
         "executable_path": "test_conformance/half/bin/test_half",
-        "arguments": "vloada_half"
+        "arguments": "vloada_half",
+        "time_limit": 120
     },
     {
         "test_name": "vstore_half",
         "test_category": "half",
         "executable_path": "test_conformance/half/bin/test_half",
-        "arguments": "vstore_half"
+        "arguments": "vstore_half",
+        "time_limit": 120
     },
     {
         "test_name": "vstorea_half",
         "test_category": "half",
         "executable_path": "test_conformance/half/bin/test_half",
-        "arguments": "vstorea_half"
+        "arguments": "vstorea_half",
+        "time_limit": 120
     },
     {
         "test_name": "vstore_half_rte",
         "test_category": "half",
         "executable_path": "test_conformance/half/bin/test_half",
-        "arguments": "vstore_half_rte"
+        "arguments": "vstore_half_rte",
+        "time_limit": 120
     },
     {
         "test_name": "vstorea_half_rte",
         "test_category": "half",
         "executable_path": "test_conformance/half/bin/test_half",
-        "arguments": "vstorea_half_rte"
+        "arguments": "vstorea_half_rte",
+        "time_limit": 120
     },
     {
         "test_name": "vstore_half_rtz",
         "test_category": "half",
         "executable_path": "test_conformance/half/bin/test_half",
-        "arguments": "vstore_half_rtz"
+        "arguments": "vstore_half_rtz",
+        "time_limit": 120
     },
     {
         "test_name": "vstorea_half_rtz",
         "test_category": "half",
         "executable_path": "test_conformance/half/bin/test_half",
-        "arguments": "vstorea_half_rtz"
+        "arguments": "vstorea_half_rtz",
+        "time_limit": 120
     },
     {
         "test_name": "vstore_half_rtp",
         "test_category": "half",
         "executable_path": "test_conformance/half/bin/test_half",
-        "arguments": "vstore_half_rtp"
+        "arguments": "vstore_half_rtp",
+        "time_limit": 120
     },
     {
         "test_name": "vstorea_half_rtp",
         "test_category": "half",
         "executable_path": "test_conformance/half/bin/test_half",
-        "arguments": "vstorea_half_rtp"
+        "arguments": "vstorea_half_rtp",
+        "time_limit": 120
     },
     {
         "test_name": "vstore_half_rtn",
         "test_category": "half",
         "executable_path": "test_conformance/half/bin/test_half",
-        "arguments": "vstore_half_rtn"
+        "arguments": "vstore_half_rtn",
+        "time_limit": 120
     },
     {
         "test_name": "vstorea_half_rtn",
         "test_category": "half",
         "executable_path": "test_conformance/half/bin/test_half",
-        "arguments": "vstorea_half_rtn"
+        "arguments": "vstorea_half_rtn",
+        "time_limit": 120
     },
     {
         "test_name": "roundTrip",
         "test_category": "half",
         "executable_path": "test_conformance/half/bin/test_half",
-        "arguments": "roundTrip"
+        "arguments": "roundTrip",
+        "time_limit": 120
     },
     {
         "test_name": "integer_clz",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "integer_clz"
+        "arguments": "integer_clz",
+        "time_limit": 120
     },
     {
         "test_name": "integer_ctz",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "integer_ctz"
+        "arguments": "integer_ctz",
+        "time_limit": 120
     },
     {
         "test_name": "integer_hadd",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "integer_hadd"
+        "arguments": "integer_hadd",
+        "time_limit": 120
     },
     {
         "test_name": "integer_rhadd",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "integer_rhadd"
+        "arguments": "integer_rhadd",
+        "time_limit": 120
     },
     {
         "test_name": "integer_mul_hi",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "integer_mul_hi"
+        "arguments": "integer_mul_hi",
+        "time_limit": 120
     },
     {
         "test_name": "integer_rotate",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "integer_rotate"
+        "arguments": "integer_rotate",
+        "time_limit": 120
     },
     {
         "test_name": "integer_clamp",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "integer_clamp"
+        "arguments": "integer_clamp",
+        "time_limit": 120
     },
     {
         "test_name": "integer_mad_sat",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "integer_mad_sat"
+        "arguments": "integer_mad_sat",
+        "time_limit": 120
     },
     {
         "test_name": "integer_mad_hi",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "integer_mad_hi"
+        "arguments": "integer_mad_hi",
+        "time_limit": 120
     },
     {
         "test_name": "integer_min",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "integer_min"
+        "arguments": "integer_min",
+        "time_limit": 120
     },
     {
         "test_name": "integer_max",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "integer_max"
+        "arguments": "integer_max",
+        "time_limit": 120
     },
     {
         "test_name": "integer_upsample",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "integer_upsample"
+        "arguments": "integer_upsample",
+        "time_limit": 120
     },
     {
         "test_name": "integer_abs",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "integer_abs"
+        "arguments": "integer_abs",
+        "time_limit": 120
     },
     {
         "test_name": "integer_abs_diff",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "integer_abs_diff"
+        "arguments": "integer_abs_diff",
+        "time_limit": 120
     },
     {
         "test_name": "integer_add_sat",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "integer_add_sat"
+        "arguments": "integer_add_sat",
+        "time_limit": 120
     },
     {
         "test_name": "integer_sub_sat",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "integer_sub_sat"
+        "arguments": "integer_sub_sat",
+        "time_limit": 120
     },
     {
         "test_name": "integer_addAssign",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "integer_addAssign"
+        "arguments": "integer_addAssign",
+        "time_limit": 120
     },
     {
         "test_name": "integer_subtractAssign",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "integer_subtractAssign"
+        "arguments": "integer_subtractAssign",
+        "time_limit": 120
     },
     {
         "test_name": "integer_multiplyAssign",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "integer_multiplyAssign"
+        "arguments": "integer_multiplyAssign",
+        "time_limit": 120
     },
     {
         "test_name": "integer_divideAssign",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "integer_divideAssign"
+        "arguments": "integer_divideAssign",
+        "time_limit": 120
     },
     {
         "test_name": "integer_moduloAssign",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "integer_moduloAssign"
+        "arguments": "integer_moduloAssign",
+        "time_limit": 120
     },
     {
         "test_name": "integer_andAssign",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "integer_andAssign"
+        "arguments": "integer_andAssign",
+        "time_limit": 120
     },
     {
         "test_name": "integer_orAssign",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "integer_orAssign"
+        "arguments": "integer_orAssign",
+        "time_limit": 120
     },
     {
         "test_name": "integer_exclusiveOrAssign",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "integer_exclusiveOrAssign"
+        "arguments": "integer_exclusiveOrAssign",
+        "time_limit": 120
     },
     {
         "test_name": "unary_ops_increment",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "unary_ops_increment"
+        "arguments": "unary_ops_increment",
+        "time_limit": 120
     },
     {
         "test_name": "unary_ops_decrement",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "unary_ops_decrement"
+        "arguments": "unary_ops_decrement",
+        "time_limit": 120
     },
     {
         "test_name": "unary_ops_full",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "unary_ops_full"
+        "arguments": "unary_ops_full",
+        "time_limit": 120
     },
     {
         "test_name": "integer_mul24",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "integer_mul24"
+        "arguments": "integer_mul24",
+        "time_limit": 120
     },
     {
         "test_name": "integer_mad24",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "integer_mad24"
+        "arguments": "integer_mad24",
+        "time_limit": 120
     },
     {
         "test_name": "long_math",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "long_math"
+        "arguments": "long_math",
+        "time_limit": 120
     },
     {
         "test_name": "long_logic",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "long_logic"
+        "arguments": "long_logic",
+        "time_limit": 120
     },
     {
         "test_name": "long_shift",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "long_shift"
+        "arguments": "long_shift",
+        "time_limit": 120
     },
     {
         "test_name": "long_compare",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "long_compare"
+        "arguments": "long_compare",
+        "time_limit": 120
     },
     {
         "test_name": "ulong_math",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "ulong_math"
+        "arguments": "ulong_math",
+        "time_limit": 120
     },
     {
         "test_name": "ulong_logic",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "ulong_logic"
+        "arguments": "ulong_logic",
+        "time_limit": 120
     },
     {
         "test_name": "ulong_shift",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "ulong_shift"
+        "arguments": "ulong_shift",
+        "time_limit": 120
     },
     {
         "test_name": "ulong_compare",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "ulong_compare"
+        "arguments": "ulong_compare",
+        "time_limit": 120
     },
     {
         "test_name": "int_math",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "int_math"
+        "arguments": "int_math",
+        "time_limit": 120
     },
     {
         "test_name": "int_logic",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "int_logic"
+        "arguments": "int_logic",
+        "time_limit": 120
     },
     {
         "test_name": "int_shift",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "int_shift"
+        "arguments": "int_shift",
+        "time_limit": 120
     },
     {
         "test_name": "int_compare",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "int_compare"
+        "arguments": "int_compare",
+        "time_limit": 120
     },
     {
         "test_name": "uint_math",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "uint_math"
+        "arguments": "uint_math",
+        "time_limit": 120
     },
     {
         "test_name": "uint_logic",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "uint_logic"
+        "arguments": "uint_logic",
+        "time_limit": 120
     },
     {
         "test_name": "uint_shift",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "uint_shift"
+        "arguments": "uint_shift",
+        "time_limit": 120
     },
     {
         "test_name": "uint_compare",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "uint_compare"
+        "arguments": "uint_compare",
+        "time_limit": 120
     },
     {
         "test_name": "short_math",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "short_math"
+        "arguments": "short_math",
+        "time_limit": 120
     },
     {
         "test_name": "short_logic",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "short_logic"
+        "arguments": "short_logic",
+        "time_limit": 120
     },
     {
         "test_name": "short_shift",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "short_shift"
+        "arguments": "short_shift",
+        "time_limit": 120
     },
     {
         "test_name": "short_compare",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "short_compare"
+        "arguments": "short_compare",
+        "time_limit": 120
     },
     {
         "test_name": "ushort_math",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "ushort_math"
+        "arguments": "ushort_math",
+        "time_limit": 120
     },
     {
         "test_name": "ushort_logic",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "ushort_logic"
+        "arguments": "ushort_logic",
+        "time_limit": 120
     },
     {
         "test_name": "ushort_shift",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "ushort_shift"
+        "arguments": "ushort_shift",
+        "time_limit": 120
     },
     {
         "test_name": "ushort_compare",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "ushort_compare"
+        "arguments": "ushort_compare",
+        "time_limit": 120
     },
     {
         "test_name": "char_math",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "char_math"
+        "arguments": "char_math",
+        "time_limit": 120
     },
     {
         "test_name": "char_logic",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "char_logic"
+        "arguments": "char_logic",
+        "time_limit": 120
     },
     {
         "test_name": "char_shift",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "char_shift"
+        "arguments": "char_shift",
+        "time_limit": 120
     },
     {
         "test_name": "char_compare",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "char_compare"
+        "arguments": "char_compare",
+        "time_limit": 120
     },
     {
         "test_name": "uchar_math",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "uchar_math"
+        "arguments": "uchar_math",
+        "time_limit": 120
     },
     {
         "test_name": "uchar_logic",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "uchar_logic"
+        "arguments": "uchar_logic",
+        "time_limit": 120
     },
     {
         "test_name": "uchar_shift",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "uchar_shift"
+        "arguments": "uchar_shift",
+        "time_limit": 120
     },
     {
         "test_name": "uchar_compare",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "uchar_compare"
+        "arguments": "uchar_compare",
+        "time_limit": 120
     },
     {
         "test_name": "popcount",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "popcount"
+        "arguments": "popcount",
+        "time_limit": 120
     },
     {
         "test_name": "quick_long_math",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "quick_long_math"
+        "arguments": "quick_long_math",
+        "time_limit": 120
     },
     {
         "test_name": "quick_long_logic",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "quick_long_logic"
+        "arguments": "quick_long_logic",
+        "time_limit": 120
     },
     {
         "test_name": "quick_long_shift",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "quick_long_shift"
+        "arguments": "quick_long_shift",
+        "time_limit": 120
     },
     {
         "test_name": "quick_long_compare",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "quick_long_compare"
+        "arguments": "quick_long_compare",
+        "time_limit": 120
     },
     {
         "test_name": "quick_ulong_math",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "quick_ulong_math"
+        "arguments": "quick_ulong_math",
+        "time_limit": 120
     },
     {
         "test_name": "quick_ulong_logic",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "quick_ulong_logic"
+        "arguments": "quick_ulong_logic",
+        "time_limit": 120
     },
     {
         "test_name": "quick_ulong_shift",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "quick_ulong_shift"
+        "arguments": "quick_ulong_shift",
+        "time_limit": 120
     },
     {
         "test_name": "quick_ulong_compare",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "quick_ulong_compare"
+        "arguments": "quick_ulong_compare",
+        "time_limit": 120
     },
     {
         "test_name": "quick_int_math",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "quick_int_math"
+        "arguments": "quick_int_math",
+        "time_limit": 120
     },
     {
         "test_name": "quick_int_logic",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "quick_int_logic"
+        "arguments": "quick_int_logic",
+        "time_limit": 120
     },
     {
         "test_name": "quick_int_shift",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "quick_int_shift"
+        "arguments": "quick_int_shift",
+        "time_limit": 120
     },
     {
         "test_name": "quick_int_compare",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "quick_int_compare"
+        "arguments": "quick_int_compare",
+        "time_limit": 120
     },
     {
         "test_name": "quick_uint_math",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "quick_uint_math"
+        "arguments": "quick_uint_math",
+        "time_limit": 120
     },
     {
         "test_name": "quick_uint_logic",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "quick_uint_logic"
+        "arguments": "quick_uint_logic",
+        "time_limit": 120
     },
     {
         "test_name": "quick_uint_shift",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "quick_uint_shift"
+        "arguments": "quick_uint_shift",
+        "time_limit": 120
     },
     {
         "test_name": "quick_uint_compare",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "quick_uint_compare"
+        "arguments": "quick_uint_compare",
+        "time_limit": 120
     },
     {
         "test_name": "quick_short_math",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "quick_short_math"
+        "arguments": "quick_short_math",
+        "time_limit": 120
     },
     {
         "test_name": "quick_short_logic",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "quick_short_logic"
+        "arguments": "quick_short_logic",
+        "time_limit": 120
     },
     {
         "test_name": "quick_short_shift",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "quick_short_shift"
+        "arguments": "quick_short_shift",
+        "time_limit": 120
     },
     {
         "test_name": "quick_short_compare",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "quick_short_compare"
+        "arguments": "quick_short_compare",
+        "time_limit": 120
     },
     {
         "test_name": "quick_ushort_math",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "quick_ushort_math"
+        "arguments": "quick_ushort_math",
+        "time_limit": 120
     },
     {
         "test_name": "quick_ushort_logic",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "quick_ushort_logic"
+        "arguments": "quick_ushort_logic",
+        "time_limit": 120
     },
     {
         "test_name": "quick_ushort_shift",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "quick_ushort_shift"
+        "arguments": "quick_ushort_shift",
+        "time_limit": 120
     },
     {
         "test_name": "quick_ushort_compare",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "quick_ushort_compare"
+        "arguments": "quick_ushort_compare",
+        "time_limit": 120
     },
     {
         "test_name": "quick_char_math",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "quick_char_math"
+        "arguments": "quick_char_math",
+        "time_limit": 120
     },
     {
         "test_name": "quick_char_logic",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "quick_char_logic"
+        "arguments": "quick_char_logic",
+        "time_limit": 120
     },
     {
         "test_name": "quick_char_shift",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "quick_char_shift"
+        "arguments": "quick_char_shift",
+        "time_limit": 120
     },
     {
         "test_name": "quick_char_compare",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "quick_char_compare"
+        "arguments": "quick_char_compare",
+        "time_limit": 120
     },
     {
         "test_name": "quick_uchar_math",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "quick_uchar_math"
+        "arguments": "quick_uchar_math",
+        "time_limit": 120
     },
     {
         "test_name": "quick_uchar_logic",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "quick_uchar_logic"
+        "arguments": "quick_uchar_logic",
+        "time_limit": 120
     },
     {
         "test_name": "quick_uchar_shift",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "quick_uchar_shift"
+        "arguments": "quick_uchar_shift",
+        "time_limit": 120
     },
     {
         "test_name": "quick_uchar_compare",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "quick_uchar_compare"
+        "arguments": "quick_uchar_compare",
+        "time_limit": 120
     },
     {
         "test_name": "vector_scalar",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
-        "arguments": "vector_scalar"
+        "arguments": "vector_scalar",
+        "time_limit": 120
     },
     {
         "test_name": "mem_host_read_only_buffer",
         "test_category": "mem_host_flags",
         "executable_path": "test_conformance/mem_host_flags/bin/test_mem_host_flags",
-        "arguments": "mem_host_read_only_buffer"
+        "arguments": "mem_host_read_only_buffer",
+        "time_limit": 120
     },
     {
         "test_name": "mem_host_read_only_subbuffer",
         "test_category": "mem_host_flags",
         "executable_path": "test_conformance/mem_host_flags/bin/test_mem_host_flags",
-        "arguments": "mem_host_read_only_subbuffer"
+        "arguments": "mem_host_read_only_subbuffer",
+        "time_limit": 120
     },
     {
         "test_name": "mem_host_write_only_buffer",
         "test_category": "mem_host_flags",
         "executable_path": "test_conformance/mem_host_flags/bin/test_mem_host_flags",
-        "arguments": "mem_host_write_only_buffer"
+        "arguments": "mem_host_write_only_buffer",
+        "time_limit": 120
     },
     {
         "test_name": "mem_host_write_only_subbuffer",
         "test_category": "mem_host_flags",
         "executable_path": "test_conformance/mem_host_flags/bin/test_mem_host_flags",
-        "arguments": "mem_host_write_only_subbuffer"
+        "arguments": "mem_host_write_only_subbuffer",
+        "time_limit": 120
     },
     {
         "test_name": "mem_host_no_access_buffer",
         "test_category": "mem_host_flags",
         "executable_path": "test_conformance/mem_host_flags/bin/test_mem_host_flags",
-        "arguments": "mem_host_no_access_buffer"
+        "arguments": "mem_host_no_access_buffer",
+        "time_limit": 120
     },
     {
         "test_name": "mem_host_no_access_subbuffer",
         "test_category": "mem_host_flags",
         "executable_path": "test_conformance/mem_host_flags/bin/test_mem_host_flags",
-        "arguments": "mem_host_no_access_subbuffer"
+        "arguments": "mem_host_no_access_subbuffer",
+        "time_limit": 120
     },
     {
         "test_name": "mem_host_read_only_image",
         "test_category": "mem_host_flags",
         "executable_path": "test_conformance/mem_host_flags/bin/test_mem_host_flags",
-        "arguments": "mem_host_read_only_image"
+        "arguments": "mem_host_read_only_image",
+        "time_limit": 120
     },
     {
         "test_name": "mem_host_write_only_image",
         "test_category": "mem_host_flags",
         "executable_path": "test_conformance/mem_host_flags/bin/test_mem_host_flags",
-        "arguments": "mem_host_write_only_image"
+        "arguments": "mem_host_write_only_image",
+        "time_limit": 120
     },
     {
         "test_name": "mem_host_no_access_image",
         "test_category": "mem_host_flags",
         "executable_path": "test_conformance/mem_host_flags/bin/test_mem_host_flags",
-        "arguments": "mem_host_no_access_image"
+        "arguments": "mem_host_no_access_image",
+        "time_limit": 120
     },
     {
         "test_name": "context_multiple_contexts_same_device",
         "test_category": "multiple_device_context",
         "executable_path": "test_conformance/multiple_device_context/bin/test_multiples",
-        "arguments": "context_multiple_contexts_same_device"
+        "arguments": "context_multiple_contexts_same_device",
+        "time_limit": 120
     },
     {
         "test_name": "context_two_contexts_same_device",
         "test_category": "multiple_device_context",
         "executable_path": "test_conformance/multiple_device_context/bin/test_multiples",
-        "arguments": "context_two_contexts_same_device"
+        "arguments": "context_two_contexts_same_device",
+        "time_limit": 120
     },
     {
         "test_name": "context_three_contexts_same_device",
         "test_category": "multiple_device_context",
         "executable_path": "test_conformance/multiple_device_context/bin/test_multiples",
-        "arguments": "context_three_contexts_same_device"
+        "arguments": "context_three_contexts_same_device",
+        "time_limit": 120
     },
     {
         "test_name": "context_four_contexts_same_device",
         "test_category": "multiple_device_context",
         "executable_path": "test_conformance/multiple_device_context/bin/test_multiples",
-        "arguments": "context_four_contexts_same_device"
+        "arguments": "context_four_contexts_same_device",
+        "time_limit": 120
     },
     {
         "test_name": "two_devices",
         "test_category": "multiple_device_context",
         "executable_path": "test_conformance/multiple_device_context/bin/test_multiples",
-        "arguments": "two_devices"
+        "arguments": "two_devices",
+        "time_limit": 120
     },
     {
         "test_name": "max_devices",
         "test_category": "multiple_device_context",
         "executable_path": "test_conformance/multiple_device_context/bin/test_multiples",
-        "arguments": "max_devices"
+        "arguments": "max_devices",
+        "time_limit": 120
     },
     {
         "test_name": "hundred_queues",
         "test_category": "multiple_device_context",
         "executable_path": "test_conformance/multiple_device_context/bin/test_multiples",
-        "arguments": "hundred_queues"
+        "arguments": "hundred_queues",
+        "time_limit": 120
     },
     {
         "test_name": "int_0",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "int_0"
+        "arguments": "int_0",
+        "time_limit": 120
     },
     {
         "test_name": "int_1",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "int_1"
+        "arguments": "int_1",
+        "time_limit": 120
     },
     {
         "test_name": "int_2",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "int_2"
+        "arguments": "int_2",
+        "time_limit": 120
     },
     {
         "test_name": "int_3",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "int_3"
+        "arguments": "int_3",
+        "time_limit": 120
     },
     {
         "test_name": "int_4",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "int_4"
+        "arguments": "int_4",
+        "time_limit": 120
     },
     {
         "test_name": "int_5",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "int_5"
+        "arguments": "int_5",
+        "time_limit": 120
     },
     {
         "test_name": "int_6",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "int_6"
+        "arguments": "int_6",
+        "time_limit": 120
     },
     {
         "test_name": "int_7",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "int_7"
+        "arguments": "int_7",
+        "time_limit": 120
     },
     {
         "test_name": "int_8",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "int_8"
+        "arguments": "int_8",
+        "time_limit": 120
     },
     {
         "test_name": "float_0",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "float_0"
+        "arguments": "float_0",
+        "time_limit": 120
     },
     {
         "test_name": "float_1",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "float_1"
+        "arguments": "float_1",
+        "time_limit": 120
     },
     {
         "test_name": "float_2",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "float_2"
+        "arguments": "float_2",
+        "time_limit": 120
     },
     {
         "test_name": "float_3",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "float_3"
+        "arguments": "float_3",
+        "time_limit": 120
     },
     {
         "test_name": "float_4",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "float_4"
+        "arguments": "float_4",
+        "time_limit": 120
     },
     {
         "test_name": "float_5",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "float_5"
+        "arguments": "float_5",
+        "time_limit": 120
     },
     {
         "test_name": "float_6",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "float_6"
+        "arguments": "float_6",
+        "time_limit": 120
     },
     {
         "test_name": "float_7",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "float_7"
+        "arguments": "float_7",
+        "time_limit": 120
     },
     {
         "test_name": "float_8",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "float_8"
+        "arguments": "float_8",
+        "time_limit": 120
     },
     {
         "test_name": "float_9",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "float_9"
+        "arguments": "float_9",
+        "time_limit": 120
     },
     {
         "test_name": "float_10",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "float_10"
+        "arguments": "float_10",
+        "time_limit": 120
     },
     {
         "test_name": "float_11",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "float_11"
+        "arguments": "float_11",
+        "time_limit": 120
     },
     {
         "test_name": "float_12",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "float_12"
+        "arguments": "float_12",
+        "time_limit": 120
     },
     {
         "test_name": "float_13",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "float_13"
+        "arguments": "float_13",
+        "time_limit": 120
     },
     {
         "test_name": "float_14",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "float_14"
+        "arguments": "float_14",
+        "time_limit": 120
     },
     {
         "test_name": "float_15",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "float_15"
+        "arguments": "float_15",
+        "time_limit": 120
     },
     {
         "test_name": "float_16",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "float_16"
+        "arguments": "float_16",
+        "time_limit": 120
     },
     {
         "test_name": "float_17",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "float_17"
+        "arguments": "float_17",
+        "time_limit": 120
     },
     {
         "test_name": "float_limits_0",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "float_limits_0"
+        "arguments": "float_limits_0",
+        "time_limit": 120
     },
     {
         "test_name": "float_limits_1",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "float_limits_1"
+        "arguments": "float_limits_1",
+        "time_limit": 120
     },
     {
         "test_name": "float_limits_2",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "float_limits_2"
+        "arguments": "float_limits_2",
+        "time_limit": 120
     },
     {
         "test_name": "octal_0",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "octal_0"
+        "arguments": "octal_0",
+        "time_limit": 120
     },
     {
         "test_name": "octal_1",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "octal_1"
+        "arguments": "octal_1",
+        "time_limit": 120
     },
     {
         "test_name": "octal_2",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "octal_2"
+        "arguments": "octal_2",
+        "time_limit": 120
     },
     {
         "test_name": "octal_3",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "octal_3"
+        "arguments": "octal_3",
+        "time_limit": 120
     },
     {
         "test_name": "unsigned_0",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "unsigned_0"
+        "arguments": "unsigned_0",
+        "time_limit": 120
     },
     {
         "test_name": "unsigned_1",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "unsigned_1"
+        "arguments": "unsigned_1",
+        "time_limit": 120
     },
     {
         "test_name": "hexadecimal_0",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "hexadecimal_0"
+        "arguments": "hexadecimal_0",
+        "time_limit": 120
     },
     {
         "test_name": "hexadecimal_1",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "hexadecimal_1"
+        "arguments": "hexadecimal_1",
+        "time_limit": 120
     },
     {
         "test_name": "hexadecimal_2",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "hexadecimal_2"
+        "arguments": "hexadecimal_2",
+        "time_limit": 120
     },
     {
         "test_name": "hexadecimal_3",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "hexadecimal_3"
+        "arguments": "hexadecimal_3",
+        "time_limit": 120
     },
     {
         "test_name": "hexadecimal_4",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "hexadecimal_4"
+        "arguments": "hexadecimal_4",
+        "time_limit": 120
     },
     {
         "test_name": "char_0",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "char_0"
+        "arguments": "char_0",
+        "time_limit": 120
     },
     {
         "test_name": "char_1",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "char_1"
+        "arguments": "char_1",
+        "time_limit": 120
     },
     {
         "test_name": "char_2",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "char_2"
+        "arguments": "char_2",
+        "time_limit": 120
     },
     {
         "test_name": "string_0",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "string_0"
+        "arguments": "string_0",
+        "time_limit": 120
     },
     {
         "test_name": "string_1",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "string_1"
+        "arguments": "string_1",
+        "time_limit": 120
     },
     {
         "test_name": "string_2",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "string_2"
+        "arguments": "string_2",
+        "time_limit": 120
     },
     {
         "test_name": "vector_0",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "vector_0"
+        "arguments": "vector_0",
+        "time_limit": 120
     },
     {
         "test_name": "vector_1",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "vector_1"
+        "arguments": "vector_1",
+        "time_limit": 120
     },
     {
         "test_name": "vector_2",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "vector_2"
+        "arguments": "vector_2",
+        "time_limit": 120
     },
     {
         "test_name": "vector_3",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "vector_3"
+        "arguments": "vector_3",
+        "time_limit": 120
     },
     {
         "test_name": "vector_4",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "vector_4"
+        "arguments": "vector_4",
+        "time_limit": 120
     },
     {
         "test_name": "address_space_0",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "address_space_0"
+        "arguments": "address_space_0",
+        "time_limit": 120
     },
     {
         "test_name": "address_space_1",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "address_space_1"
+        "arguments": "address_space_1",
+        "time_limit": 120
     },
     {
         "test_name": "address_space_2",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "address_space_2"
+        "arguments": "address_space_2",
+        "time_limit": 120
     },
     {
         "test_name": "address_space_3",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "address_space_3"
+        "arguments": "address_space_3",
+        "time_limit": 120
     },
     {
         "test_name": "address_space_4",
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
-        "arguments": "address_space_4"
+        "arguments": "address_space_4",
+        "time_limit": 120
     },
     {
         "test_name": "read_array_int",
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
-        "arguments": "read_array_int"
+        "arguments": "read_array_int",
+        "time_limit": 120
     },
     {
         "test_name": "read_array_uint",
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
-        "arguments": "read_array_uint"
+        "arguments": "read_array_uint",
+        "time_limit": 120
     },
     {
         "test_name": "read_array_long",
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
-        "arguments": "read_array_long"
+        "arguments": "read_array_long",
+        "time_limit": 120
     },
     {
         "test_name": "read_array_ulong",
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
-        "arguments": "read_array_ulong"
+        "arguments": "read_array_ulong",
+        "time_limit": 120
     },
     {
         "test_name": "read_array_short",
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
-        "arguments": "read_array_short"
+        "arguments": "read_array_short",
+        "time_limit": 120
     },
     {
         "test_name": "read_array_ushort",
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
-        "arguments": "read_array_ushort"
+        "arguments": "read_array_ushort",
+        "time_limit": 120
     },
     {
         "test_name": "read_array_float",
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
-        "arguments": "read_array_float"
+        "arguments": "read_array_float",
+        "time_limit": 120
     },
     {
         "test_name": "read_array_char",
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
-        "arguments": "read_array_char"
+        "arguments": "read_array_char",
+        "time_limit": 120
     },
     {
         "test_name": "read_array_uchar",
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
-        "arguments": "read_array_uchar"
+        "arguments": "read_array_uchar",
+        "time_limit": 120
     },
     {
         "test_name": "read_array_struct",
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
-        "arguments": "read_array_struct"
+        "arguments": "read_array_struct",
+        "time_limit": 120
     },
     {
         "test_name": "write_array_int",
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
-        "arguments": "write_array_int"
+        "arguments": "write_array_int",
+        "time_limit": 120
     },
     {
         "test_name": "write_array_uint",
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
-        "arguments": "write_array_uint"
+        "arguments": "write_array_uint",
+        "time_limit": 120
     },
     {
         "test_name": "write_array_long",
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
-        "arguments": "write_array_long"
+        "arguments": "write_array_long",
+        "time_limit": 120
     },
     {
         "test_name": "write_array_ulong",
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
-        "arguments": "write_array_ulong"
+        "arguments": "write_array_ulong",
+        "time_limit": 120
     },
     {
         "test_name": "write_array_short",
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
-        "arguments": "write_array_short"
+        "arguments": "write_array_short",
+        "time_limit": 120
     },
     {
         "test_name": "write_array_ushort",
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
-        "arguments": "write_array_ushort"
+        "arguments": "write_array_ushort",
+        "time_limit": 120
     },
     {
         "test_name": "write_array_float",
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
-        "arguments": "write_array_float"
+        "arguments": "write_array_float",
+        "time_limit": 120
     },
     {
         "test_name": "write_array_char",
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
-        "arguments": "write_array_char"
+        "arguments": "write_array_char",
+        "time_limit": 120
     },
     {
         "test_name": "write_array_uchar",
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
-        "arguments": "write_array_uchar"
+        "arguments": "write_array_uchar",
+        "time_limit": 120
     },
     {
         "test_name": "write_array_struct",
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
-        "arguments": "write_array_struct"
+        "arguments": "write_array_struct",
+        "time_limit": 120
     },
     {
         "test_name": "read_image_float",
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
-        "arguments": "read_image_float"
+        "arguments": "read_image_float",
+        "time_limit": 120
     },
     {
         "test_name": "read_image_char",
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
-        "arguments": "read_image_char"
+        "arguments": "read_image_char",
+        "time_limit": 120
     },
     {
         "test_name": "read_image_uchar",
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
-        "arguments": "read_image_uchar"
+        "arguments": "read_image_uchar",
+        "time_limit": 120
     },
     {
         "test_name": "write_image_float",
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
-        "arguments": "write_image_float"
+        "arguments": "write_image_float",
+        "time_limit": 120
     },
     {
         "test_name": "write_image_char",
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
-        "arguments": "write_image_char"
+        "arguments": "write_image_char",
+        "time_limit": 120
     },
     {
         "test_name": "write_image_uchar",
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
-        "arguments": "write_image_uchar"
+        "arguments": "write_image_uchar",
+        "time_limit": 120
     },
     {
         "test_name": "copy_array",
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
-        "arguments": "copy_array"
+        "arguments": "copy_array",
+        "time_limit": 120
     },
     {
         "test_name": "copy_partial_array",
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
-        "arguments": "copy_partial_array"
+        "arguments": "copy_partial_array",
+        "time_limit": 120
     },
     {
         "test_name": "copy_image",
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
-        "arguments": "copy_image"
+        "arguments": "copy_image",
+        "time_limit": 120
     },
     {
         "test_name": "copy_array_to_image",
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
-        "arguments": "copy_array_to_image"
+        "arguments": "copy_array_to_image",
+        "time_limit": 120
     },
     {
         "test_name": "execute",
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
-        "arguments": "execute"
+        "arguments": "execute",
+        "time_limit": 120
     },
     {
         "test_name": "relational_any",
         "test_category": "relationals",
         "executable_path": "test_conformance/relationals/bin/test_relationals",
-        "arguments": "relational_any"
+        "arguments": "relational_any",
+        "time_limit": 120
     },
     {
         "test_name": "relational_all",
         "test_category": "relationals",
         "executable_path": "test_conformance/relationals/bin/test_relationals",
-        "arguments": "relational_all"
+        "arguments": "relational_all",
+        "time_limit": 120
     },
     {
         "test_name": "relational_bitselect",
         "test_category": "relationals",
         "executable_path": "test_conformance/relationals/bin/test_relationals",
-        "arguments": "relational_bitselect"
+        "arguments": "relational_bitselect",
+        "time_limit": 120
     },
     {
         "test_name": "relational_select_signed",
         "test_category": "relationals",
         "executable_path": "test_conformance/relationals/bin/test_relationals",
-        "arguments": "relational_select_signed"
+        "arguments": "relational_select_signed",
+        "time_limit": 120
     },
     {
         "test_name": "relational_select_unsigned",
         "test_category": "relationals",
         "executable_path": "test_conformance/relationals/bin/test_relationals",
-        "arguments": "relational_select_unsigned"
+        "arguments": "relational_select_unsigned",
+        "time_limit": 120
     },
     {
         "test_name": "relational_isequal",
         "test_category": "relationals",
         "executable_path": "test_conformance/relationals/bin/test_relationals",
-        "arguments": "relational_isequal"
+        "arguments": "relational_isequal",
+        "time_limit": 120
     },
     {
         "test_name": "relational_isnotequal",
         "test_category": "relationals",
         "executable_path": "test_conformance/relationals/bin/test_relationals",
-        "arguments": "relational_isnotequal"
+        "arguments": "relational_isnotequal",
+        "time_limit": 120
     },
     {
         "test_name": "relational_isgreater",
         "test_category": "relationals",
         "executable_path": "test_conformance/relationals/bin/test_relationals",
-        "arguments": "relational_isgreater"
+        "arguments": "relational_isgreater",
+        "time_limit": 120
     },
     {
         "test_name": "relational_isgreaterequal",
         "test_category": "relationals",
         "executable_path": "test_conformance/relationals/bin/test_relationals",
-        "arguments": "relational_isgreaterequal"
+        "arguments": "relational_isgreaterequal",
+        "time_limit": 120
     },
     {
         "test_name": "relational_isless",
         "test_category": "relationals",
         "executable_path": "test_conformance/relationals/bin/test_relationals",
-        "arguments": "relational_isless"
+        "arguments": "relational_isless",
+        "time_limit": 120
     },
     {
         "test_name": "relational_islessequal",
         "test_category": "relationals",
         "executable_path": "test_conformance/relationals/bin/test_relationals",
-        "arguments": "relational_islessequal"
+        "arguments": "relational_islessequal",
+        "time_limit": 120
     },
     {
         "test_name": "relational_islessgreater",
         "test_category": "relationals",
         "executable_path": "test_conformance/relationals/bin/test_relationals",
-        "arguments": "relational_islessgreater"
+        "arguments": "relational_islessgreater",
+        "time_limit": 120
     },
     {
         "test_name": "shuffle_copy",
         "test_category": "relationals",
         "executable_path": "test_conformance/relationals/bin/test_relationals",
-        "arguments": "shuffle_copy"
+        "arguments": "shuffle_copy",
+        "time_limit": 120
     },
     {
         "test_name": "shuffle_function_call",
         "test_category": "relationals",
         "executable_path": "test_conformance/relationals/bin/test_relationals",
-        "arguments": "shuffle_function_call"
+        "arguments": "shuffle_function_call",
+        "time_limit": 120
     },
     {
         "test_name": "shuffle_array_cast",
         "test_category": "relationals",
         "executable_path": "test_conformance/relationals/bin/test_relationals",
-        "arguments": "shuffle_array_cast"
+        "arguments": "shuffle_array_cast",
+        "time_limit": 120
     },
     {
         "test_name": "shuffle_built_in",
         "test_category": "relationals",
         "executable_path": "test_conformance/relationals/bin/test_relationals",
-        "arguments": "shuffle_built_in"
+        "arguments": "shuffle_built_in",
+        "time_limit": 120
     },
     {
         "test_name": "shuffle_built_in_dual_input",
         "test_category": "relationals",
         "executable_path": "test_conformance/relationals/bin/test_relationals",
-        "arguments": "shuffle_built_in_dual_input"
+        "arguments": "shuffle_built_in_dual_input",
+        "time_limit": 120
     },
     {
         "test_name": "select_uchar_uchar",
         "test_category": "select",
         "executable_path": "test_conformance/select/bin/test_select",
-        "arguments": "select_uchar_uchar"
+        "arguments": "select_uchar_uchar",
+        "time_limit": 120
     },
     {
         "test_name": "select_uchar_char",
         "test_category": "select",
         "executable_path": "test_conformance/select/bin/test_select",
-        "arguments": "select_uchar_char"
+        "arguments": "select_uchar_char",
+        "time_limit": 120
     },
     {
         "test_name": "select_char_uchar",
         "test_category": "select",
         "executable_path": "test_conformance/select/bin/test_select",
-        "arguments": "select_char_uchar"
+        "arguments": "select_char_uchar",
+        "time_limit": 120
     },
     {
         "test_name": "select_char_char",
         "test_category": "select",
         "executable_path": "test_conformance/select/bin/test_select",
-        "arguments": "select_char_char"
+        "arguments": "select_char_char",
+        "time_limit": 120
     },
     {
         "test_name": "select_ushort_ushort",
         "test_category": "select",
         "executable_path": "test_conformance/select/bin/test_select",
-        "arguments": "select_ushort_ushort"
+        "arguments": "select_ushort_ushort",
+        "time_limit": 120
     },
     {
         "test_name": "select_ushort_short",
         "test_category": "select",
         "executable_path": "test_conformance/select/bin/test_select",
-        "arguments": "select_ushort_short"
+        "arguments": "select_ushort_short",
+        "time_limit": 120
     },
     {
         "test_name": "select_short_ushort",
         "test_category": "select",
         "executable_path": "test_conformance/select/bin/test_select",
-        "arguments": "select_short_ushort"
+        "arguments": "select_short_ushort",
+        "time_limit": 120
     },
     {
         "test_name": "select_short_short",
         "test_category": "select",
         "executable_path": "test_conformance/select/bin/test_select",
-        "arguments": "select_short_short"
+        "arguments": "select_short_short",
+        "time_limit": 120
     },
     {
         "test_name": "select_uint_uint",
         "test_category": "select",
         "executable_path": "test_conformance/select/bin/test_select",
-        "arguments": "select_uint_uint"
+        "arguments": "select_uint_uint",
+        "time_limit": 120
     },
     {
         "test_name": "select_uint_int",
         "test_category": "select",
         "executable_path": "test_conformance/select/bin/test_select",
-        "arguments": "select_uint_int"
+        "arguments": "select_uint_int",
+        "time_limit": 120
     },
     {
         "test_name": "select_int_uint",
         "test_category": "select",
         "executable_path": "test_conformance/select/bin/test_select",
-        "arguments": "select_int_uint"
+        "arguments": "select_int_uint",
+        "time_limit": 120
     },
     {
         "test_name": "select_int_int",
         "test_category": "select",
         "executable_path": "test_conformance/select/bin/test_select",
-        "arguments": "select_int_int"
+        "arguments": "select_int_int",
+        "time_limit": 120
     },
     {
         "test_name": "select_float_uint",
         "test_category": "select",
         "executable_path": "test_conformance/select/bin/test_select",
-        "arguments": "select_float_uint"
+        "arguments": "select_float_uint",
+        "time_limit": 120
     },
     {
         "test_name": "select_float_int",
         "test_category": "select",
         "executable_path": "test_conformance/select/bin/test_select",
-        "arguments": "select_float_int"
+        "arguments": "select_float_int",
+        "time_limit": 120
     },
     {
         "test_name": "select_ulong_ulong",
         "test_category": "select",
         "executable_path": "test_conformance/select/bin/test_select",
-        "arguments": "select_ulong_ulong"
+        "arguments": "select_ulong_ulong",
+        "time_limit": 120
     },
     {
         "test_name": "select_ulong_long",
         "test_category": "select",
         "executable_path": "test_conformance/select/bin/test_select",
-        "arguments": "select_ulong_long"
+        "arguments": "select_ulong_long",
+        "time_limit": 120
     },
     {
         "test_name": "select_long_ulong",
         "test_category": "select",
         "executable_path": "test_conformance/select/bin/test_select",
-        "arguments": "select_long_ulong"
+        "arguments": "select_long_ulong",
+        "time_limit": 120
     },
     {
         "test_name": "select_long_long",
         "test_category": "select",
         "executable_path": "test_conformance/select/bin/test_select",
-        "arguments": "select_long_long"
+        "arguments": "select_long_long",
+        "time_limit": 120
     },
     {
         "test_name": "select_double_ulong",
         "test_category": "select",
         "executable_path": "test_conformance/select/bin/test_select",
-        "arguments": "select_double_ulong"
+        "arguments": "select_double_ulong",
+        "time_limit": 120
     },
     {
         "test_name": "select_double_long",
         "test_category": "select",
         "executable_path": "test_conformance/select/bin/test_select",
-        "arguments": "select_double_long"
+        "arguments": "select_double_long",
+        "time_limit": 120
     },
     {
         "test_name": "quick_1d_explicit_local",
         "test_category": "thread_dimensions",
         "executable_path": "test_conformance/thread_dimensions/bin/test_thread_dimensions",
-        "arguments": "quick_1d_explicit_local"
+        "arguments": "quick_1d_explicit_local",
+        "time_limit": 120
     },
     {
         "test_name": "quick_2d_explicit_local",
         "test_category": "thread_dimensions",
         "executable_path": "test_conformance/thread_dimensions/bin/test_thread_dimensions",
-        "arguments": "quick_2d_explicit_local"
+        "arguments": "quick_2d_explicit_local",
+        "time_limit": 120
     },
     {
         "test_name": "quick_3d_explicit_local",
         "test_category": "thread_dimensions",
         "executable_path": "test_conformance/thread_dimensions/bin/test_thread_dimensions",
-        "arguments": "quick_3d_explicit_local"
+        "arguments": "quick_3d_explicit_local",
+        "time_limit": 120
     },
     {
         "test_name": "quick_1d_implicit_local",
         "test_category": "thread_dimensions",
         "executable_path": "test_conformance/thread_dimensions/bin/test_thread_dimensions",
-        "arguments": "quick_1d_implicit_local"
+        "arguments": "quick_1d_implicit_local",
+        "time_limit": 120
     },
     {
         "test_name": "quick_2d_implicit_local",
         "test_category": "thread_dimensions",
         "executable_path": "test_conformance/thread_dimensions/bin/test_thread_dimensions",
-        "arguments": "quick_2d_implicit_local"
+        "arguments": "quick_2d_implicit_local",
+        "time_limit": 120
     },
     {
         "test_name": "quick_3d_implicit_local",
         "test_category": "thread_dimensions",
         "executable_path": "test_conformance/thread_dimensions/bin/test_thread_dimensions",
-        "arguments": "quick_3d_implicit_local"
+        "arguments": "quick_3d_implicit_local",
+        "time_limit": 120
     },
     {
         "test_name": "full_1d_explicit_local",
         "test_category": "thread_dimensions",
         "executable_path": "test_conformance/thread_dimensions/bin/test_thread_dimensions",
-        "arguments": "full_1d_explicit_local"
+        "arguments": "full_1d_explicit_local",
+        "time_limit": 120
     },
     {
         "test_name": "full_2d_explicit_local",
         "test_category": "thread_dimensions",
         "executable_path": "test_conformance/thread_dimensions/bin/test_thread_dimensions",
-        "arguments": "full_2d_explicit_local"
+        "arguments": "full_2d_explicit_local",
+        "time_limit": 120
     },
     {
         "test_name": "full_3d_explicit_local",
         "test_category": "thread_dimensions",
         "executable_path": "test_conformance/thread_dimensions/bin/test_thread_dimensions",
-        "arguments": "full_3d_explicit_local"
+        "arguments": "full_3d_explicit_local",
+        "time_limit": 120
     },
     {
         "test_name": "full_1d_implicit_local",
         "test_category": "thread_dimensions",
         "executable_path": "test_conformance/thread_dimensions/bin/test_thread_dimensions",
-        "arguments": "full_1d_implicit_local"
+        "arguments": "full_1d_implicit_local",
+        "time_limit": 120
     },
     {
         "test_name": "full_2d_implicit_local",
         "test_category": "thread_dimensions",
         "executable_path": "test_conformance/thread_dimensions/bin/test_thread_dimensions",
-        "arguments": "full_2d_implicit_local"
+        "arguments": "full_2d_implicit_local",
+        "time_limit": 120
     },
     {
         "test_name": "full_3d_implicit_local",
         "test_category": "thread_dimensions",
         "executable_path": "test_conformance/thread_dimensions/bin/test_thread_dimensions",
-        "arguments": "full_3d_implicit_local"
+        "arguments": "full_3d_implicit_local",
+        "time_limit": 120
     },
     {
         "test_name": "step_type",
         "test_category": "vectors",
         "executable_path": "test_conformance/vectors/bin/test_vectors",
-        "arguments": "step_type"
+        "arguments": "step_type",
+        "time_limit": 120
     },
     {
         "test_name": "step_var",
         "test_category": "vectors",
         "executable_path": "test_conformance/vectors/bin/test_vectors",
-        "arguments": "step_var"
+        "arguments": "step_var",
+        "time_limit": 120
     },
     {
         "test_name": "step_typedef_type",
         "test_category": "vectors",
         "executable_path": "test_conformance/vectors/bin/test_vectors",
-        "arguments": "step_typedef_type"
+        "arguments": "step_typedef_type",
+        "time_limit": 120
     },
     {
         "test_name": "step_typedef_var",
         "test_category": "vectors",
         "executable_path": "test_conformance/vectors/bin/test_vectors",
-        "arguments": "step_typedef_var"
+        "arguments": "step_typedef_var",
+        "time_limit": 120
     },
     {
         "test_name": "vec_align_array",
         "test_category": "vectors",
         "executable_path": "test_conformance/vectors/bin/test_vectors",
-        "arguments": "vec_align_array"
+        "arguments": "vec_align_array",
+        "time_limit": 120
     },
     {
         "test_name": "vec_align_struct",
         "test_category": "vectors",
         "executable_path": "test_conformance/vectors/bin/test_vectors",
-        "arguments": "vec_align_struct"
+        "arguments": "vec_align_struct",
+        "time_limit": 120
     },
     {
         "test_name": "vec_align_packed_struct",
         "test_category": "vectors",
         "executable_path": "test_conformance/vectors/bin/test_vectors",
-        "arguments": "vec_align_packed_struct"
+        "arguments": "vec_align_packed_struct",
+        "time_limit": 120
     },
     {
         "test_name": "vec_align_struct_arr",
         "test_category": "vectors",
         "executable_path": "test_conformance/vectors/bin/test_vectors",
-        "arguments": "vec_align_struct_arr"
+        "arguments": "vec_align_struct_arr",
+        "time_limit": 120
     },
     {
         "test_name": "vec_align_packed_struct_arr",
         "test_category": "vectors",
         "executable_path": "test_conformance/vectors/bin/test_vectors",
-        "arguments": "vec_align_packed_struct_arr"
+        "arguments": "vec_align_packed_struct_arr",
+        "time_limit": 120
     },
     {
         "test_name": "atomic_init",
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
-        "arguments": "atomic_init"
+        "arguments": "atomic_init",
+        "time_limit": 120
     },
     {
         "test_name": "atomic_store",
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
-        "arguments": "atomic_store"
+        "arguments": "atomic_store",
+        "time_limit": 120
     },
     {
         "test_name": "atomic_load",
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
-        "arguments": "atomic_load"
+        "arguments": "atomic_load",
+        "time_limit": 120
     },
     {
         "test_name": "atomic_exchange",
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
-        "arguments": "atomic_exchange"
+        "arguments": "atomic_exchange",
+        "time_limit": 120
     },
     {
         "test_name": "atomic_compare_exchange_weak",
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
-        "arguments": "atomic_compare_exchange_weak"
+        "arguments": "atomic_compare_exchange_weak",
+        "time_limit": 120
     },
     {
         "test_name": "atomic_compare_exchange_strong",
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
-        "arguments": "atomic_compare_exchange_strong"
+        "arguments": "atomic_compare_exchange_strong",
+        "time_limit": 120
     },
     {
         "test_name": "atomic_fetch_add",
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
-        "arguments": "atomic_fetch_add"
+        "arguments": "atomic_fetch_add",
+        "time_limit": 120
     },
     {
         "test_name": "atomic_fetch_sub",
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
-        "arguments": "atomic_fetch_sub"
+        "arguments": "atomic_fetch_sub",
+        "time_limit": 120
     },
     {
         "test_name": "atomic_fetch_and",
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
-        "arguments": "atomic_fetch_and"
+        "arguments": "atomic_fetch_and",
+        "time_limit": 120
     },
     {
         "test_name": "atomic_fetch_or",
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
-        "arguments": "atomic_fetch_or"
+        "arguments": "atomic_fetch_or",
+        "time_limit": 120
     },
     {
         "test_name": "atomic_fetch_orand",
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
-        "arguments": "atomic_fetch_orand"
+        "arguments": "atomic_fetch_orand",
+        "time_limit": 120
     },
     {
         "test_name": "atomic_fetch_xor",
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
-        "arguments": "atomic_fetch_xor"
+        "arguments": "atomic_fetch_xor",
+        "time_limit": 120
     },
     {
         "test_name": "atomic_fetch_xor2",
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
-        "arguments": "atomic_fetch_xor2"
+        "arguments": "atomic_fetch_xor2",
+        "time_limit": 120
     },
     {
         "test_name": "atomic_fetch_min",
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
-        "arguments": "atomic_fetch_min"
+        "arguments": "atomic_fetch_min",
+        "time_limit": 120
     },
     {
         "test_name": "atomic_fetch_max",
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
-        "arguments": "atomic_fetch_max"
+        "arguments": "atomic_fetch_max",
+        "time_limit": 120
     },
     {
         "test_name": "atomic_flag",
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
-        "arguments": "atomic_flag"
+        "arguments": "atomic_flag",
+        "time_limit": 120
     },
     {
         "test_name": "atomic_fence",
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
-        "arguments": "atomic_fence"
+        "arguments": "atomic_fence",
+        "time_limit": 120
     },
     {
         "test_name": "svm_atomic_init",
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
-        "arguments": "svm_atomic_init"
+        "arguments": "svm_atomic_init",
+        "time_limit": 120
     },
     {
         "test_name": "svm_atomic_store",
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
-        "arguments": "svm_atomic_store"
+        "arguments": "svm_atomic_store",
+        "time_limit": 120
     },
     {
         "test_name": "svm_atomic_load",
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
-        "arguments": "svm_atomic_load"
+        "arguments": "svm_atomic_load",
+        "time_limit": 120
     },
     {
         "test_name": "svm_atomic_exchange",
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
-        "arguments": "svm_atomic_exchange"
+        "arguments": "svm_atomic_exchange",
+        "time_limit": 120
     },
     {
         "test_name": "svm_atomic_compare_exchange_weak",
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
-        "arguments": "svm_atomic_compare_exchange_weak"
+        "arguments": "svm_atomic_compare_exchange_weak",
+        "time_limit": 120
     },
     {
         "test_name": "svm_atomic_compare_exchange_strong",
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
-        "arguments": "svm_atomic_compare_exchange_strong"
+        "arguments": "svm_atomic_compare_exchange_strong",
+        "time_limit": 120
     },
     {
         "test_name": "svm_atomic_fetch_add",
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
-        "arguments": "svm_atomic_fetch_add"
+        "arguments": "svm_atomic_fetch_add",
+        "time_limit": 120
     },
     {
         "test_name": "svm_atomic_fetch_sub",
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
-        "arguments": "svm_atomic_fetch_sub"
+        "arguments": "svm_atomic_fetch_sub",
+        "time_limit": 120
     },
     {
         "test_name": "svm_atomic_fetch_and",
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
-        "arguments": "svm_atomic_fetch_and"
+        "arguments": "svm_atomic_fetch_and",
+        "time_limit": 120
     },
     {
         "test_name": "svm_atomic_fetch_or",
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
-        "arguments": "svm_atomic_fetch_or"
+        "arguments": "svm_atomic_fetch_or",
+        "time_limit": 120
     },
     {
         "test_name": "svm_atomic_fetch_orand",
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
-        "arguments": "svm_atomic_fetch_orand"
+        "arguments": "svm_atomic_fetch_orand",
+        "time_limit": 120
     },
     {
         "test_name": "svm_atomic_fetch_xor",
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
-        "arguments": "svm_atomic_fetch_xor"
+        "arguments": "svm_atomic_fetch_xor",
+        "time_limit": 120
     },
     {
         "test_name": "svm_atomic_fetch_xor2",
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
-        "arguments": "svm_atomic_fetch_xor2"
+        "arguments": "svm_atomic_fetch_xor2",
+        "time_limit": 120
     },
     {
         "test_name": "svm_atomic_fetch_min",
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
-        "arguments": "svm_atomic_fetch_min"
+        "arguments": "svm_atomic_fetch_min",
+        "time_limit": 120
     },
     {
         "test_name": "svm_atomic_fetch_max",
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
-        "arguments": "svm_atomic_fetch_max"
+        "arguments": "svm_atomic_fetch_max",
+        "time_limit": 120
     },
     {
         "test_name": "svm_atomic_flag",
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
-        "arguments": "svm_atomic_flag"
+        "arguments": "svm_atomic_flag",
+        "time_limit": 120
     },
     {
         "test_name": "svm_atomic_fence",
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
-        "arguments": "svm_atomic_fence"
+        "arguments": "svm_atomic_fence",
+        "time_limit": 120
     },
     {
         "test_name": "device_info",
         "test_category": "device_execution",
         "executable_path": "test_conformance/device_execution/bin/test_device_execution",
-        "arguments": "device_info"
+        "arguments": "device_info",
+        "time_limit": 120
     },
     {
         "test_name": "device_queue",
         "test_category": "device_execution",
         "executable_path": "test_conformance/device_execution/bin/test_device_execution",
-        "arguments": "device_queue"
+        "arguments": "device_queue",
+        "time_limit": 120
     },
     {
         "test_name": "execute_block",
         "test_category": "device_execution",
         "executable_path": "test_conformance/device_execution/bin/test_device_execution",
-        "arguments": "execute_block"
+        "arguments": "execute_block",
+        "time_limit": 120
     },
     {
         "test_name": "enqueue_block",
         "test_category": "device_execution",
         "executable_path": "test_conformance/device_execution/bin/test_device_execution",
-        "arguments": "enqueue_block"
+        "arguments": "enqueue_block",
+        "time_limit": 120
     },
     {
         "test_name": "enqueue_nested_blocks",
         "test_category": "device_execution",
         "executable_path": "test_conformance/device_execution/bin/test_device_execution",
-        "arguments": "enqueue_nested_blocks"
+        "arguments": "enqueue_nested_blocks",
+        "time_limit": 120
     },
     {
         "test_name": "enqueue_wg_size",
         "test_category": "device_execution",
         "executable_path": "test_conformance/device_execution/bin/test_device_execution",
-        "arguments": "enqueue_wg_size"
+        "arguments": "enqueue_wg_size",
+        "time_limit": 120
     },
     {
         "test_name": "enqueue_flags",
         "test_category": "device_execution",
         "executable_path": "test_conformance/device_execution/bin/test_device_execution",
-        "arguments": "enqueue_flags"
+        "arguments": "enqueue_flags",
+        "time_limit": 120
     },
     {
         "test_name": "enqueue_multi_queue",
         "test_category": "device_execution",
         "executable_path": "test_conformance/device_execution/bin/test_device_execution",
-        "arguments": "enqueue_multi_queue"
+        "arguments": "enqueue_multi_queue",
+        "time_limit": 120
     },
     {
         "test_name": "host_multi_queue",
         "test_category": "device_execution",
         "executable_path": "test_conformance/device_execution/bin/test_device_execution",
-        "arguments": "host_multi_queue"
+        "arguments": "host_multi_queue",
+        "time_limit": 120
     },
     {
         "test_name": "enqueue_ndrange",
         "test_category": "device_execution",
         "executable_path": "test_conformance/device_execution/bin/test_device_execution",
-        "arguments": "enqueue_ndrange"
+        "arguments": "enqueue_ndrange",
+        "time_limit": 120
     },
     {
         "test_name": "host_queue_order",
         "test_category": "device_execution",
         "executable_path": "test_conformance/device_execution/bin/test_device_execution",
-        "arguments": "host_queue_order"
+        "arguments": "host_queue_order",
+        "time_limit": 120
     },
     {
         "test_name": "enqueue_profiling",
         "test_category": "device_execution",
         "executable_path": "test_conformance/device_execution/bin/test_device_execution",
-        "arguments": "enqueue_profiling"
+        "arguments": "enqueue_profiling",
+        "time_limit": 120
     },
     {
         "test_name": "non_uniform_1d_basic",
         "test_category": "non_uniform_work_group",
         "executable_path": "test_conformance/non_uniform_work_group/bin/test_non_uniform_work_group",
-        "arguments": "non_uniform_1d_basic"
+        "arguments": "non_uniform_1d_basic",
+        "time_limit": 120
     },
     {
         "test_name": "non_uniform_1d_atomics",
         "test_category": "non_uniform_work_group",
         "executable_path": "test_conformance/non_uniform_work_group/bin/test_non_uniform_work_group",
-        "arguments": "non_uniform_1d_atomics"
+        "arguments": "non_uniform_1d_atomics",
+        "time_limit": 120
     },
     {
         "test_name": "non_uniform_1d_barriers",
         "test_category": "non_uniform_work_group",
         "executable_path": "test_conformance/non_uniform_work_group/bin/test_non_uniform_work_group",
-        "arguments": "non_uniform_1d_barriers"
+        "arguments": "non_uniform_1d_barriers",
+        "time_limit": 120
     },
     {
         "test_name": "non_uniform_2d_basic",
         "test_category": "non_uniform_work_group",
         "executable_path": "test_conformance/non_uniform_work_group/bin/test_non_uniform_work_group",
-        "arguments": "non_uniform_2d_basic"
+        "arguments": "non_uniform_2d_basic",
+        "time_limit": 120
     },
     {
         "test_name": "non_uniform_2d_atomics",
         "test_category": "non_uniform_work_group",
         "executable_path": "test_conformance/non_uniform_work_group/bin/test_non_uniform_work_group",
-        "arguments": "non_uniform_2d_atomics"
+        "arguments": "non_uniform_2d_atomics",
+        "time_limit": 120
     },
     {
         "test_name": "non_uniform_2d_barriers",
         "test_category": "non_uniform_work_group",
         "executable_path": "test_conformance/non_uniform_work_group/bin/test_non_uniform_work_group",
-        "arguments": "non_uniform_2d_barriers"
+        "arguments": "non_uniform_2d_barriers",
+        "time_limit": 120
     },
     {
         "test_name": "non_uniform_3d_basic",
         "test_category": "non_uniform_work_group",
         "executable_path": "test_conformance/non_uniform_work_group/bin/test_non_uniform_work_group",
-        "arguments": "non_uniform_3d_basic"
+        "arguments": "non_uniform_3d_basic",
+        "time_limit": 120
     },
     {
         "test_name": "non_uniform_3d_atomics",
         "test_category": "non_uniform_work_group",
         "executable_path": "test_conformance/non_uniform_work_group/bin/test_non_uniform_work_group",
-        "arguments": "non_uniform_3d_atomics"
+        "arguments": "non_uniform_3d_atomics",
+        "time_limit": 120
     },
     {
         "test_name": "non_uniform_3d_barriers",
         "test_category": "non_uniform_work_group",
         "executable_path": "test_conformance/non_uniform_work_group/bin/test_non_uniform_work_group",
-        "arguments": "non_uniform_3d_barriers"
+        "arguments": "non_uniform_3d_barriers",
+        "time_limit": 120
     },
     {
         "test_name": "non_uniform_other_basic",
         "test_category": "non_uniform_work_group",
         "executable_path": "test_conformance/non_uniform_work_group/bin/test_non_uniform_work_group",
-        "arguments": "non_uniform_other_basic"
+        "arguments": "non_uniform_other_basic",
+        "time_limit": 120
     },
     {
         "test_name": "non_uniform_other_atomics",
         "test_category": "non_uniform_work_group",
         "executable_path": "test_conformance/non_uniform_work_group/bin/test_non_uniform_work_group",
-        "arguments": "non_uniform_other_atomics"
+        "arguments": "non_uniform_other_atomics",
+        "time_limit": 120
     },
     {
         "test_name": "non_uniform_other_barriers",
         "test_category": "non_uniform_work_group",
         "executable_path": "test_conformance/non_uniform_work_group/bin/test_non_uniform_work_group",
-        "arguments": "non_uniform_other_barriers"
+        "arguments": "non_uniform_other_barriers",
+        "time_limit": 120
     },
     {
         "test_name": "function_get_fence",
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
-        "arguments": "function_get_fence"
+        "arguments": "function_get_fence",
+        "time_limit": 120
     },
     {
         "test_name": "function_to_address_space",
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
-        "arguments": "function_to_address_space"
+        "arguments": "function_to_address_space",
+        "time_limit": 120
     },
     {
         "test_name": "variable_get_fence",
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
-        "arguments": "variable_get_fence"
+        "arguments": "variable_get_fence",
+        "time_limit": 120
     },
     {
         "test_name": "variable_to_address_space",
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
-        "arguments": "variable_to_address_space"
+        "arguments": "variable_to_address_space",
+        "time_limit": 120
     },
     {
         "test_name": "casting",
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
-        "arguments": "casting"
+        "arguments": "casting",
+        "time_limit": 120
     },
     {
         "test_name": "conditional_casting",
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
-        "arguments": "conditional_casting"
+        "arguments": "conditional_casting",
+        "time_limit": 120
     },
     {
         "test_name": "chain_casting",
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
-        "arguments": "chain_casting"
+        "arguments": "chain_casting",
+        "time_limit": 120
     },
     {
         "test_name": "ternary_operator_casting",
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
-        "arguments": "ternary_operator_casting"
+        "arguments": "ternary_operator_casting",
+        "time_limit": 120
     },
     {
         "test_name": "language_struct",
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
-        "arguments": "language_struct"
+        "arguments": "language_struct",
+        "time_limit": 120
     },
     {
         "test_name": "language_union",
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
-        "arguments": "language_union"
+        "arguments": "language_union",
+        "time_limit": 120
     },
     {
         "test_name": "multiple_calls_same_function",
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
-        "arguments": "multiple_calls_same_function"
+        "arguments": "multiple_calls_same_function",
+        "time_limit": 120
     },
     {
         "test_name": "compare_pointers",
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
-        "arguments": "compare_pointers"
+        "arguments": "compare_pointers",
+        "time_limit": 120
     },
     {
         "test_name": "library_function",
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
-        "arguments": "library_function"
+        "arguments": "library_function",
+        "time_limit": 120
     },
     {
         "test_name": "generic_variable_volatile",
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
-        "arguments": "generic_variable_volatile"
+        "arguments": "generic_variable_volatile",
+        "time_limit": 120
     },
     {
         "test_name": "generic_variable_const",
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
-        "arguments": "generic_variable_const"
+        "arguments": "generic_variable_const",
+        "time_limit": 120
     },
     {
         "test_name": "generic_variable_gentype",
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
-        "arguments": "generic_variable_gentype"
+        "arguments": "generic_variable_gentype",
+        "time_limit": 120
     },
     {
         "test_name": "builtin_functions",
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
-        "arguments": "builtin_functions"
+        "arguments": "builtin_functions",
+        "time_limit": 120
     },
     {
         "test_name": "generic_advanced_casting",
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
-        "arguments": "generic_advanced_casting"
+        "arguments": "generic_advanced_casting",
+        "time_limit": 120
     },
     {
         "test_name": "generic_ptr_to_host_mem",
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
-        "arguments": "generic_ptr_to_host_mem"
+        "arguments": "generic_ptr_to_host_mem",
+        "time_limit": 120
     },
     {
         "test_name": "generic_ptr_to_host_mem_svm",
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
-        "arguments": "generic_ptr_to_host_mem_svm"
+        "arguments": "generic_ptr_to_host_mem_svm",
+        "time_limit": 120
     },
     {
         "test_name": "max_number_of_params",
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
-        "arguments": "max_number_of_params"
+        "arguments": "max_number_of_params",
+        "time_limit": 120
     },
     {
         "test_name": "sub_group_info_ext",
         "test_category": "subgroups",
         "executable_path": "test_conformance/subgroups/bin/test_subgroups",
-        "arguments": "sub_group_info_ext"
+        "arguments": "sub_group_info_ext",
+        "time_limit": 120
     },
     {
         "test_name": "sub_group_info_core",
         "test_category": "subgroups",
         "executable_path": "test_conformance/subgroups/bin/test_subgroups",
-        "arguments": "sub_group_info_core"
+        "arguments": "sub_group_info_core",
+        "time_limit": 120
     },
     {
         "test_name": "work_item_functions_ext",
         "test_category": "subgroups",
         "executable_path": "test_conformance/subgroups/bin/test_subgroups",
-        "arguments": "work_item_functions_ext"
+        "arguments": "work_item_functions_ext",
+        "time_limit": 120
     },
     {
         "test_name": "work_item_functions_core",
         "test_category": "subgroups",
         "executable_path": "test_conformance/subgroups/bin/test_subgroups",
-        "arguments": "work_item_functions_core"
+        "arguments": "work_item_functions_core",
+        "time_limit": 120
     },
     {
         "test_name": "subgroup_functions_ext",
         "test_category": "subgroups",
         "executable_path": "test_conformance/subgroups/bin/test_subgroups",
-        "arguments": "subgroup_functions_ext"
+        "arguments": "subgroup_functions_ext",
+        "time_limit": 120
     },
     {
         "test_name": "subgroup_functions_core",
         "test_category": "subgroups",
         "executable_path": "test_conformance/subgroups/bin/test_subgroups",
-        "arguments": "subgroup_functions_core"
+        "arguments": "subgroup_functions_core",
+        "time_limit": 120
     },
     {
         "test_name": "barrier_functions_ext",
         "test_category": "subgroups",
         "executable_path": "test_conformance/subgroups/bin/test_subgroups",
-        "arguments": "barrier_functions_ext"
+        "arguments": "barrier_functions_ext",
+        "time_limit": 120
     },
     {
         "test_name": "barrier_functions_core",
         "test_category": "subgroups",
         "executable_path": "test_conformance/subgroups/bin/test_subgroups",
-        "arguments": "barrier_functions_core"
+        "arguments": "barrier_functions_core",
+        "time_limit": 120
     },
     {
         "test_name": "ifp_ext",
         "test_category": "subgroups",
         "executable_path": "test_conformance/subgroups/bin/test_subgroups",
-        "arguments": "ifp_ext"
+        "arguments": "ifp_ext",
+        "time_limit": 120
     },
     {
         "test_name": "ifp_core",
         "test_category": "subgroups",
         "executable_path": "test_conformance/subgroups/bin/test_subgroups",
-        "arguments": "ifp_core"
+        "arguments": "ifp_core",
+        "time_limit": 120
     },
     {
         "test_name": "subgroup_functions_extended_types",
         "test_category": "subgroups",
         "executable_path": "test_conformance/subgroups/bin/test_subgroups",
-        "arguments": "subgroup_functions_extended_types"
+        "arguments": "subgroup_functions_extended_types",
+        "time_limit": 120
     },
     {
         "test_name": "subgroup_functions_non_uniform_vote",
         "test_category": "subgroups",
         "executable_path": "test_conformance/subgroups/bin/test_subgroups",
-        "arguments": "subgroup_functions_non_uniform_vote"
+        "arguments": "subgroup_functions_non_uniform_vote",
+        "time_limit": 120
     },
     {
         "test_name": "subgroup_functions_non_uniform_arithmetic",
         "test_category": "subgroups",
         "executable_path": "test_conformance/subgroups/bin/test_subgroups",
-        "arguments": "subgroup_functions_non_uniform_arithmetic"
+        "arguments": "subgroup_functions_non_uniform_arithmetic",
+        "time_limit": 120
     },
     {
         "test_name": "subgroup_functions_ballot",
         "test_category": "subgroups",
         "executable_path": "test_conformance/subgroups/bin/test_subgroups",
-        "arguments": "subgroup_functions_ballot"
+        "arguments": "subgroup_functions_ballot",
+        "time_limit": 120
     },
     {
         "test_name": "subgroup_functions_clustered_reduce",
         "test_category": "subgroups",
         "executable_path": "test_conformance/subgroups/bin/test_subgroups",
-        "arguments": "subgroup_functions_clustered_reduce"
+        "arguments": "subgroup_functions_clustered_reduce",
+        "time_limit": 120
     },
     {
         "test_name": "subgroup_functions_shuffle",
         "test_category": "subgroups",
         "executable_path": "test_conformance/subgroups/bin/test_subgroups",
-        "arguments": "subgroup_functions_shuffle"
+        "arguments": "subgroup_functions_shuffle",
+        "time_limit": 120
     },
     {
         "test_name": "subgroup_functions_shuffle_relative",
         "test_category": "subgroups",
         "executable_path": "test_conformance/subgroups/bin/test_subgroups",
-        "arguments": "subgroup_functions_shuffle_relative"
+        "arguments": "subgroup_functions_shuffle_relative",
+        "time_limit": 120
     },
     {
         "test_name": "work_group_all",
         "test_category": "workgroups",
         "executable_path": "test_conformance/workgroups/bin/test_workgroups",
-        "arguments": "work_group_all"
+        "arguments": "work_group_all",
+        "time_limit": 120
     },
     {
         "test_name": "work_group_any",
         "test_category": "workgroups",
         "executable_path": "test_conformance/workgroups/bin/test_workgroups",
-        "arguments": "work_group_any"
+        "arguments": "work_group_any",
+        "time_limit": 120
     },
     {
         "test_name": "work_group_reduce_add",
         "test_category": "workgroups",
         "executable_path": "test_conformance/workgroups/bin/test_workgroups",
-        "arguments": "work_group_reduce_add"
+        "arguments": "work_group_reduce_add",
+        "time_limit": 120
     },
     {
         "test_name": "work_group_reduce_min",
         "test_category": "workgroups",
         "executable_path": "test_conformance/workgroups/bin/test_workgroups",
-        "arguments": "work_group_reduce_min"
+        "arguments": "work_group_reduce_min",
+        "time_limit": 120
     },
     {
         "test_name": "work_group_reduce_max",
         "test_category": "workgroups",
         "executable_path": "test_conformance/workgroups/bin/test_workgroups",
-        "arguments": "work_group_reduce_max"
+        "arguments": "work_group_reduce_max",
+        "time_limit": 120
     },
     {
         "test_name": "work_group_scan_inclusive_add",
         "test_category": "workgroups",
         "executable_path": "test_conformance/workgroups/bin/test_workgroups",
-        "arguments": "work_group_scan_inclusive_add"
+        "arguments": "work_group_scan_inclusive_add",
+        "time_limit": 120
     },
     {
         "test_name": "work_group_scan_inclusive_min",
         "test_category": "workgroups",
         "executable_path": "test_conformance/workgroups/bin/test_workgroups",
-        "arguments": "work_group_scan_inclusive_min"
+        "arguments": "work_group_scan_inclusive_min",
+        "time_limit": 120
     },
     {
         "test_name": "work_group_scan_inclusive_max",
         "test_category": "workgroups",
         "executable_path": "test_conformance/workgroups/bin/test_workgroups",
-        "arguments": "work_group_scan_inclusive_max"
+        "arguments": "work_group_scan_inclusive_max",
+        "time_limit": 120
     },
     {
         "test_name": "work_group_scan_exclusive_add",
         "test_category": "workgroups",
         "executable_path": "test_conformance/workgroups/bin/test_workgroups",
-        "arguments": "work_group_scan_exclusive_add"
+        "arguments": "work_group_scan_exclusive_add",
+        "time_limit": 120
     },
     {
         "test_name": "work_group_scan_exclusive_min",
         "test_category": "workgroups",
         "executable_path": "test_conformance/workgroups/bin/test_workgroups",
-        "arguments": "work_group_scan_exclusive_min"
+        "arguments": "work_group_scan_exclusive_min",
+        "time_limit": 120
     },
     {
         "test_name": "work_group_scan_exclusive_max",
         "test_category": "workgroups",
         "executable_path": "test_conformance/workgroups/bin/test_workgroups",
-        "arguments": "work_group_scan_exclusive_max"
+        "arguments": "work_group_scan_exclusive_max",
+        "time_limit": 120
     },
     {
         "test_name": "work_group_broadcast_1D",
         "test_category": "workgroups",
         "executable_path": "test_conformance/workgroups/bin/test_workgroups",
-        "arguments": "work_group_broadcast_1D"
+        "arguments": "work_group_broadcast_1D",
+        "time_limit": 120
     },
     {
         "test_name": "work_group_broadcast_2D",
         "test_category": "workgroups",
         "executable_path": "test_conformance/workgroups/bin/test_workgroups",
-        "arguments": "work_group_broadcast_2D"
+        "arguments": "work_group_broadcast_2D",
+        "time_limit": 120
     },
     {
         "test_name": "work_group_broadcast_3D",
         "test_category": "workgroups",
         "executable_path": "test_conformance/workgroups/bin/test_workgroups",
-        "arguments": "work_group_broadcast_3D"
+        "arguments": "work_group_broadcast_3D",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_readwrite_int",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_readwrite_int"
+        "arguments": "pipe_readwrite_int",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_readwrite_uint",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_readwrite_uint"
+        "arguments": "pipe_readwrite_uint",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_readwrite_long",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_readwrite_long"
+        "arguments": "pipe_readwrite_long",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_readwrite_ulong",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_readwrite_ulong"
+        "arguments": "pipe_readwrite_ulong",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_readwrite_short",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_readwrite_short"
+        "arguments": "pipe_readwrite_short",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_readwrite_ushort",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_readwrite_ushort"
+        "arguments": "pipe_readwrite_ushort",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_readwrite_float",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_readwrite_float"
+        "arguments": "pipe_readwrite_float",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_readwrite_half",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_readwrite_half"
+        "arguments": "pipe_readwrite_half",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_readwrite_char",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_readwrite_char"
+        "arguments": "pipe_readwrite_char",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_readwrite_uchar",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_readwrite_uchar"
+        "arguments": "pipe_readwrite_uchar",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_readwrite_double",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_readwrite_double"
+        "arguments": "pipe_readwrite_double",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_readwrite_struct",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_readwrite_struct"
+        "arguments": "pipe_readwrite_struct",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_workgroup_readwrite_int",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_workgroup_readwrite_int"
+        "arguments": "pipe_workgroup_readwrite_int",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_workgroup_readwrite_uint",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_workgroup_readwrite_uint"
+        "arguments": "pipe_workgroup_readwrite_uint",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_workgroup_readwrite_long",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_workgroup_readwrite_long"
+        "arguments": "pipe_workgroup_readwrite_long",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_workgroup_readwrite_ulong",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_workgroup_readwrite_ulong"
+        "arguments": "pipe_workgroup_readwrite_ulong",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_workgroup_readwrite_short",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_workgroup_readwrite_short"
+        "arguments": "pipe_workgroup_readwrite_short",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_workgroup_readwrite_ushort",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_workgroup_readwrite_ushort"
+        "arguments": "pipe_workgroup_readwrite_ushort",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_workgroup_readwrite_float",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_workgroup_readwrite_float"
+        "arguments": "pipe_workgroup_readwrite_float",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_workgroup_readwrite_half",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_workgroup_readwrite_half"
+        "arguments": "pipe_workgroup_readwrite_half",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_workgroup_readwrite_char",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_workgroup_readwrite_char"
+        "arguments": "pipe_workgroup_readwrite_char",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_workgroup_readwrite_uchar",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_workgroup_readwrite_uchar"
+        "arguments": "pipe_workgroup_readwrite_uchar",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_workgroup_readwrite_double",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_workgroup_readwrite_double"
+        "arguments": "pipe_workgroup_readwrite_double",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_workgroup_readwrite_struct",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_workgroup_readwrite_struct"
+        "arguments": "pipe_workgroup_readwrite_struct",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_subgroup_readwrite_int",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_subgroup_readwrite_int"
+        "arguments": "pipe_subgroup_readwrite_int",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_subgroup_readwrite_uint",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_subgroup_readwrite_uint"
+        "arguments": "pipe_subgroup_readwrite_uint",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_subgroup_readwrite_long",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_subgroup_readwrite_long"
+        "arguments": "pipe_subgroup_readwrite_long",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_subgroup_readwrite_ulong",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_subgroup_readwrite_ulong"
+        "arguments": "pipe_subgroup_readwrite_ulong",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_subgroup_readwrite_short",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_subgroup_readwrite_short"
+        "arguments": "pipe_subgroup_readwrite_short",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_subgroup_readwrite_ushort",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_subgroup_readwrite_ushort"
+        "arguments": "pipe_subgroup_readwrite_ushort",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_subgroup_readwrite_float",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_subgroup_readwrite_float"
+        "arguments": "pipe_subgroup_readwrite_float",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_subgroup_readwrite_half",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_subgroup_readwrite_half"
+        "arguments": "pipe_subgroup_readwrite_half",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_subgroup_readwrite_char",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_subgroup_readwrite_char"
+        "arguments": "pipe_subgroup_readwrite_char",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_subgroup_readwrite_uchar",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_subgroup_readwrite_uchar"
+        "arguments": "pipe_subgroup_readwrite_uchar",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_subgroup_readwrite_double",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_subgroup_readwrite_double"
+        "arguments": "pipe_subgroup_readwrite_double",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_subgroup_readwrite_struct",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_subgroup_readwrite_struct"
+        "arguments": "pipe_subgroup_readwrite_struct",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_convenience_readwrite_int",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_convenience_readwrite_int"
+        "arguments": "pipe_convenience_readwrite_int",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_convenience_readwrite_uint",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_convenience_readwrite_uint"
+        "arguments": "pipe_convenience_readwrite_uint",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_convenience_readwrite_long",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_convenience_readwrite_long"
+        "arguments": "pipe_convenience_readwrite_long",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_convenience_readwrite_ulong",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_convenience_readwrite_ulong"
+        "arguments": "pipe_convenience_readwrite_ulong",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_convenience_readwrite_short",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_convenience_readwrite_short"
+        "arguments": "pipe_convenience_readwrite_short",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_convenience_readwrite_ushort",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_convenience_readwrite_ushort"
+        "arguments": "pipe_convenience_readwrite_ushort",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_convenience_readwrite_float",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_convenience_readwrite_float"
+        "arguments": "pipe_convenience_readwrite_float",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_convenience_readwrite_half",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_convenience_readwrite_half"
+        "arguments": "pipe_convenience_readwrite_half",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_convenience_readwrite_char",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_convenience_readwrite_char"
+        "arguments": "pipe_convenience_readwrite_char",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_convenience_readwrite_uchar",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_convenience_readwrite_uchar"
+        "arguments": "pipe_convenience_readwrite_uchar",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_convenience_readwrite_double",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_convenience_readwrite_double"
+        "arguments": "pipe_convenience_readwrite_double",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_convenience_readwrite_struct",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_convenience_readwrite_struct"
+        "arguments": "pipe_convenience_readwrite_struct",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_info",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_info"
+        "arguments": "pipe_info",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_max_args",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_max_args"
+        "arguments": "pipe_max_args",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_max_packet_size",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_max_packet_size"
+        "arguments": "pipe_max_packet_size",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_max_active_reservations",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_max_active_reservations"
+        "arguments": "pipe_max_active_reservations",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_query_functions",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_query_functions"
+        "arguments": "pipe_query_functions",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_readwrite_errors",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_readwrite_errors"
+        "arguments": "pipe_readwrite_errors",
+        "time_limit": 120
     },
     {
         "test_name": "pipe_subgroups_divergence",
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
-        "arguments": "pipe_subgroups_divergence"
+        "arguments": "pipe_subgroups_divergence",
+        "time_limit": 120
     },
     {
         "test_name": "timer_resolution_queries",
         "test_category": "device_timer",
         "executable_path": "test_conformance/device_timer/bin/test_device_timer",
-        "arguments": "timer_resolution_queries"
+        "arguments": "timer_resolution_queries",
+        "time_limit": 120
     },
     {
         "test_name": "device_and_host_timers",
         "test_category": "device_timer",
         "executable_path": "test_conformance/device_timer/bin/test_device_timer",
-        "arguments": "device_and_host_timers"
+        "arguments": "device_and_host_timers",
+        "time_limit": 120
     },
     {
         "test_name": "ext_cl_khr_spirv_no_integer_wrap_decoration_fadd_int",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "ext_cl_khr_spirv_no_integer_wrap_decoration_fadd_int"
+        "arguments": "ext_cl_khr_spirv_no_integer_wrap_decoration_fadd_int",
+        "time_limit": 120
     },
     {
         "test_name": "ext_cl_khr_spirv_no_integer_wrap_decoration_fsub_int",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "ext_cl_khr_spirv_no_integer_wrap_decoration_fsub_int"
+        "arguments": "ext_cl_khr_spirv_no_integer_wrap_decoration_fsub_int",
+        "time_limit": 120
     },
     {
         "test_name": "ext_cl_khr_spirv_no_integer_wrap_decoration_fmul_int",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "ext_cl_khr_spirv_no_integer_wrap_decoration_fmul_int"
+        "arguments": "ext_cl_khr_spirv_no_integer_wrap_decoration_fmul_int",
+        "time_limit": 120
     },
     {
         "test_name": "ext_cl_khr_spirv_no_integer_wrap_decoration_fshiftleft_int",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "ext_cl_khr_spirv_no_integer_wrap_decoration_fshiftleft_int"
+        "arguments": "ext_cl_khr_spirv_no_integer_wrap_decoration_fshiftleft_int",
+        "time_limit": 120
     },
     {
         "test_name": "ext_cl_khr_spirv_no_integer_wrap_decoration_fnegate_int",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "ext_cl_khr_spirv_no_integer_wrap_decoration_fnegate_int"
+        "arguments": "ext_cl_khr_spirv_no_integer_wrap_decoration_fnegate_int",
+        "time_limit": 120
     },
     {
         "test_name": "ext_cl_khr_spirv_no_integer_wrap_decoration_fadd_uint",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "ext_cl_khr_spirv_no_integer_wrap_decoration_fadd_uint"
+        "arguments": "ext_cl_khr_spirv_no_integer_wrap_decoration_fadd_uint",
+        "time_limit": 120
     },
     {
         "test_name": "ext_cl_khr_spirv_no_integer_wrap_decoration_fsub_uint",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "ext_cl_khr_spirv_no_integer_wrap_decoration_fsub_uint"
+        "arguments": "ext_cl_khr_spirv_no_integer_wrap_decoration_fsub_uint",
+        "time_limit": 120
     },
     {
         "test_name": "ext_cl_khr_spirv_no_integer_wrap_decoration_fmul_uint",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "ext_cl_khr_spirv_no_integer_wrap_decoration_fmul_uint"
+        "arguments": "ext_cl_khr_spirv_no_integer_wrap_decoration_fmul_uint",
+        "time_limit": 120
     },
     {
         "test_name": "ext_cl_khr_spirv_no_integer_wrap_decoration_fshiftleft_uint",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "ext_cl_khr_spirv_no_integer_wrap_decoration_fshiftleft_uint"
+        "arguments": "ext_cl_khr_spirv_no_integer_wrap_decoration_fshiftleft_uint",
+        "time_limit": 120
     },
     {
         "test_name": "decorate_restrict",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "decorate_restrict"
+        "arguments": "decorate_restrict",
+        "time_limit": 120
     },
     {
         "test_name": "decorate_aliased",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "decorate_aliased"
+        "arguments": "decorate_aliased",
+        "time_limit": 120
     },
     {
         "test_name": "decorate_alignment",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "decorate_alignment"
+        "arguments": "decorate_alignment",
+        "time_limit": 120
     },
     {
         "test_name": "decorate_constant",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "decorate_constant"
+        "arguments": "decorate_constant",
+        "time_limit": 120
     },
     {
         "test_name": "decorate_cpacked",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "decorate_cpacked"
+        "arguments": "decorate_cpacked",
+        "time_limit": 120
     },
     {
         "test_name": "decorate_saturated_conversion_char",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "decorate_saturated_conversion_char"
+        "arguments": "decorate_saturated_conversion_char",
+        "time_limit": 120
     },
     {
         "test_name": "decorate_saturated_conversion_uchar",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "decorate_saturated_conversion_uchar"
+        "arguments": "decorate_saturated_conversion_uchar",
+        "time_limit": 120
     },
     {
         "test_name": "decorate_saturated_conversion_short",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "decorate_saturated_conversion_short"
+        "arguments": "decorate_saturated_conversion_short",
+        "time_limit": 120
     },
     {
         "test_name": "decorate_saturated_conversion_ushort",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "decorate_saturated_conversion_ushort"
+        "arguments": "decorate_saturated_conversion_ushort",
+        "time_limit": 120
     },
     {
         "test_name": "decorate_saturated_conversion_int",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "decorate_saturated_conversion_int"
+        "arguments": "decorate_saturated_conversion_int",
+        "time_limit": 120
     },
     {
         "test_name": "decorate_saturated_conversion_uint",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "decorate_saturated_conversion_uint"
+        "arguments": "decorate_saturated_conversion_uint",
+        "time_limit": 120
     },
     {
         "test_name": "decorate_fp_rounding_mode_rte_float_int",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "decorate_fp_rounding_mode_rte_float_int"
+        "arguments": "decorate_fp_rounding_mode_rte_float_int",
+        "time_limit": 120
     },
     {
         "test_name": "decorate_fp_rounding_mode_rtz_float_int",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "decorate_fp_rounding_mode_rtz_float_int"
+        "arguments": "decorate_fp_rounding_mode_rtz_float_int",
+        "time_limit": 120
     },
     {
         "test_name": "decorate_fp_rounding_mode_rtp_float_int",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "decorate_fp_rounding_mode_rtp_float_int"
+        "arguments": "decorate_fp_rounding_mode_rtp_float_int",
+        "time_limit": 120
     },
     {
         "test_name": "decorate_fp_rounding_mode_rtn_float_int",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "decorate_fp_rounding_mode_rtn_float_int"
+        "arguments": "decorate_fp_rounding_mode_rtn_float_int",
+        "time_limit": 120
     },
     {
         "test_name": "decorate_fp_rounding_mode_rte_double_long",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "decorate_fp_rounding_mode_rte_double_long"
+        "arguments": "decorate_fp_rounding_mode_rte_double_long",
+        "time_limit": 120
     },
     {
         "test_name": "decorate_fp_rounding_mode_rtz_double_long",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "decorate_fp_rounding_mode_rtz_double_long"
+        "arguments": "decorate_fp_rounding_mode_rtz_double_long",
+        "time_limit": 120
     },
     {
         "test_name": "decorate_fp_rounding_mode_rtp_double_long",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "decorate_fp_rounding_mode_rtp_double_long"
+        "arguments": "decorate_fp_rounding_mode_rtp_double_long",
+        "time_limit": 120
     },
     {
         "test_name": "decorate_fp_rounding_mode_rtn_double_long",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "decorate_fp_rounding_mode_rtn_double_long"
+        "arguments": "decorate_fp_rounding_mode_rtn_double_long",
+        "time_limit": 120
     },
     {
         "test_name": "get_program_il",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "get_program_il"
+        "arguments": "get_program_il",
+        "time_limit": 120
     },
     {
         "test_name": "linkage_export_function_compile",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "linkage_export_function_compile"
+        "arguments": "linkage_export_function_compile",
+        "time_limit": 120
     },
     {
         "test_name": "linkage_import_function_compile",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "linkage_import_function_compile"
+        "arguments": "linkage_import_function_compile",
+        "time_limit": 120
     },
     {
         "test_name": "linkage_import_function_link",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "linkage_import_function_link"
+        "arguments": "linkage_import_function_link",
+        "time_limit": 120
     },
     {
         "test_name": "op_atomic_inc_global",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_atomic_inc_global"
+        "arguments": "op_atomic_inc_global",
+        "time_limit": 120
     },
     {
         "test_name": "op_atomic_dec_global",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_atomic_dec_global"
+        "arguments": "op_atomic_dec_global",
+        "time_limit": 120
     },
     {
         "test_name": "op_label_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_label_simple"
+        "arguments": "op_label_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_branch_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_branch_simple"
+        "arguments": "op_branch_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_unreachable_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_unreachable_simple"
+        "arguments": "op_unreachable_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_branch_conditional",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_branch_conditional"
+        "arguments": "op_branch_conditional",
+        "time_limit": 120
     },
     {
         "test_name": "op_branch_conditional_weighted",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_branch_conditional_weighted"
+        "arguments": "op_branch_conditional_weighted",
+        "time_limit": 120
     },
     {
         "test_name": "op_composite_construct_int4",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_composite_construct_int4"
+        "arguments": "op_composite_construct_int4",
+        "time_limit": 120
     },
     {
         "test_name": "op_composite_construct_struct",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_composite_construct_struct"
+        "arguments": "op_composite_construct_struct",
+        "time_limit": 120
     },
     {
         "test_name": "op_constant_true_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_constant_true_simple"
+        "arguments": "op_constant_true_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_constant_false_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_constant_false_simple"
+        "arguments": "op_constant_false_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_constant_int_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_constant_int_simple"
+        "arguments": "op_constant_int_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_constant_uint_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_constant_uint_simple"
+        "arguments": "op_constant_uint_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_constant_char_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_constant_char_simple"
+        "arguments": "op_constant_char_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_constant_uchar_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_constant_uchar_simple"
+        "arguments": "op_constant_uchar_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_constant_ushort_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_constant_ushort_simple"
+        "arguments": "op_constant_ushort_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_constant_long_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_constant_long_simple"
+        "arguments": "op_constant_long_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_constant_ulong_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_constant_ulong_simple"
+        "arguments": "op_constant_ulong_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_constant_short_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_constant_short_simple"
+        "arguments": "op_constant_short_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_constant_float_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_constant_float_simple"
+        "arguments": "op_constant_float_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_constant_double_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_constant_double_simple"
+        "arguments": "op_constant_double_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_constant_int4_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_constant_int4_simple"
+        "arguments": "op_constant_int4_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_constant_int3_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_constant_int3_simple"
+        "arguments": "op_constant_int3_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_constant_struct_int_float_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_constant_struct_int_float_simple"
+        "arguments": "op_constant_struct_int_float_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_constant_struct_int_char_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_constant_struct_int_char_simple"
+        "arguments": "op_constant_struct_int_char_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_constant_struct_struct_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_constant_struct_struct_simple"
+        "arguments": "op_constant_struct_struct_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_constant_half_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_constant_half_simple"
+        "arguments": "op_constant_half_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_copy_int_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_copy_int_simple"
+        "arguments": "op_copy_int_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_copy_uint_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_copy_uint_simple"
+        "arguments": "op_copy_uint_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_copy_char_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_copy_char_simple"
+        "arguments": "op_copy_char_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_copy_uchar_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_copy_uchar_simple"
+        "arguments": "op_copy_uchar_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_copy_ushort_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_copy_ushort_simple"
+        "arguments": "op_copy_ushort_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_copy_long_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_copy_long_simple"
+        "arguments": "op_copy_long_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_copy_ulong_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_copy_ulong_simple"
+        "arguments": "op_copy_ulong_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_copy_short_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_copy_short_simple"
+        "arguments": "op_copy_short_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_copy_float_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_copy_float_simple"
+        "arguments": "op_copy_float_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_copy_double_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_copy_double_simple"
+        "arguments": "op_copy_double_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_copy_int4_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_copy_int4_simple"
+        "arguments": "op_copy_int4_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_copy_int3_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_copy_int3_simple"
+        "arguments": "op_copy_int3_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_copy_struct_int_float_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_copy_struct_int_float_simple"
+        "arguments": "op_copy_struct_int_float_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_copy_struct_int_char_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_copy_struct_int_char_simple"
+        "arguments": "op_copy_struct_int_char_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_copy_struct_struct_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_copy_struct_struct_simple"
+        "arguments": "op_copy_struct_struct_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_copy_half_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_copy_half_simple"
+        "arguments": "op_copy_half_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_fadd_float_regular",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fadd_float_regular"
+        "arguments": "op_fadd_float_regular",
+        "time_limit": 120
     },
     {
         "test_name": "op_fsub_float_regular",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fsub_float_regular"
+        "arguments": "op_fsub_float_regular",
+        "time_limit": 120
     },
     {
         "test_name": "op_fmul_float_regular",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fmul_float_regular"
+        "arguments": "op_fmul_float_regular",
+        "time_limit": 120
     },
     {
         "test_name": "op_fdiv_float_regular",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fdiv_float_regular"
+        "arguments": "op_fdiv_float_regular",
+        "time_limit": 120
     },
     {
         "test_name": "op_frem_float_regular",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_frem_float_regular"
+        "arguments": "op_frem_float_regular",
+        "time_limit": 120
     },
     {
         "test_name": "op_fmod_float_regular",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fmod_float_regular"
+        "arguments": "op_fmod_float_regular",
+        "time_limit": 120
     },
     {
         "test_name": "op_fadd_float_fast",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fadd_float_fast"
+        "arguments": "op_fadd_float_fast",
+        "time_limit": 120
     },
     {
         "test_name": "op_fsub_float_fast",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fsub_float_fast"
+        "arguments": "op_fsub_float_fast",
+        "time_limit": 120
     },
     {
         "test_name": "op_fmul_float_fast",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fmul_float_fast"
+        "arguments": "op_fmul_float_fast",
+        "time_limit": 120
     },
     {
         "test_name": "op_fdiv_float_fast",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fdiv_float_fast"
+        "arguments": "op_fdiv_float_fast",
+        "time_limit": 120
     },
     {
         "test_name": "op_frem_float_fast",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_frem_float_fast"
+        "arguments": "op_frem_float_fast",
+        "time_limit": 120
     },
     {
         "test_name": "op_fmod_float_fast",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fmod_float_fast"
+        "arguments": "op_fmod_float_fast",
+        "time_limit": 120
     },
     {
         "test_name": "op_fadd_double_regular",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fadd_double_regular"
+        "arguments": "op_fadd_double_regular",
+        "time_limit": 120
     },
     {
         "test_name": "op_fsub_double_regular",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fsub_double_regular"
+        "arguments": "op_fsub_double_regular",
+        "time_limit": 120
     },
     {
         "test_name": "op_fmul_double_regular",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fmul_double_regular"
+        "arguments": "op_fmul_double_regular",
+        "time_limit": 120
     },
     {
         "test_name": "op_fdiv_double_regular",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fdiv_double_regular"
+        "arguments": "op_fdiv_double_regular",
+        "time_limit": 120
     },
     {
         "test_name": "op_frem_double_regular",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_frem_double_regular"
+        "arguments": "op_frem_double_regular",
+        "time_limit": 120
     },
     {
         "test_name": "op_fmod_double_regular",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fmod_double_regular"
+        "arguments": "op_fmod_double_regular",
+        "time_limit": 120
     },
     {
         "test_name": "op_fadd_double_fast",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fadd_double_fast"
+        "arguments": "op_fadd_double_fast",
+        "time_limit": 120
     },
     {
         "test_name": "op_fsub_double_fast",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fsub_double_fast"
+        "arguments": "op_fsub_double_fast",
+        "time_limit": 120
     },
     {
         "test_name": "op_fmul_double_fast",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fmul_double_fast"
+        "arguments": "op_fmul_double_fast",
+        "time_limit": 120
     },
     {
         "test_name": "op_fdiv_double_fast",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fdiv_double_fast"
+        "arguments": "op_fdiv_double_fast",
+        "time_limit": 120
     },
     {
         "test_name": "op_frem_double_fast",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_frem_double_fast"
+        "arguments": "op_frem_double_fast",
+        "time_limit": 120
     },
     {
         "test_name": "op_fmod_double_fast",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fmod_double_fast"
+        "arguments": "op_fmod_double_fast",
+        "time_limit": 120
     },
     {
         "test_name": "op_fadd_float4_regular",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fadd_float4_regular"
+        "arguments": "op_fadd_float4_regular",
+        "time_limit": 120
     },
     {
         "test_name": "op_fsub_float4_regular",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fsub_float4_regular"
+        "arguments": "op_fsub_float4_regular",
+        "time_limit": 120
     },
     {
         "test_name": "op_fmul_float4_regular",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fmul_float4_regular"
+        "arguments": "op_fmul_float4_regular",
+        "time_limit": 120
     },
     {
         "test_name": "op_fdiv_float4_regular",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fdiv_float4_regular"
+        "arguments": "op_fdiv_float4_regular",
+        "time_limit": 120
     },
     {
         "test_name": "op_frem_float4_regular",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_frem_float4_regular"
+        "arguments": "op_frem_float4_regular",
+        "time_limit": 120
     },
     {
         "test_name": "op_fmod_float4_regular",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fmod_float4_regular"
+        "arguments": "op_fmod_float4_regular",
+        "time_limit": 120
     },
     {
         "test_name": "op_fadd_float4_fast",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fadd_float4_fast"
+        "arguments": "op_fadd_float4_fast",
+        "time_limit": 120
     },
     {
         "test_name": "op_fsub_float4_fast",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fsub_float4_fast"
+        "arguments": "op_fsub_float4_fast",
+        "time_limit": 120
     },
     {
         "test_name": "op_fmul_float4_fast",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fmul_float4_fast"
+        "arguments": "op_fmul_float4_fast",
+        "time_limit": 120
     },
     {
         "test_name": "op_fdiv_float4_fast",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fdiv_float4_fast"
+        "arguments": "op_fdiv_float4_fast",
+        "time_limit": 120
     },
     {
         "test_name": "op_frem_float4_fast",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_frem_float4_fast"
+        "arguments": "op_frem_float4_fast",
+        "time_limit": 120
     },
     {
         "test_name": "op_fmod_float4_fast",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fmod_float4_fast"
+        "arguments": "op_fmod_float4_fast",
+        "time_limit": 120
     },
     {
         "test_name": "op_fadd_double2_regular",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fadd_double2_regular"
+        "arguments": "op_fadd_double2_regular",
+        "time_limit": 120
     },
     {
         "test_name": "op_fsub_double2_regular",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fsub_double2_regular"
+        "arguments": "op_fsub_double2_regular",
+        "time_limit": 120
     },
     {
         "test_name": "op_fmul_double2_regular",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fmul_double2_regular"
+        "arguments": "op_fmul_double2_regular",
+        "time_limit": 120
     },
     {
         "test_name": "op_fdiv_double2_regular",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fdiv_double2_regular"
+        "arguments": "op_fdiv_double2_regular",
+        "time_limit": 120
     },
     {
         "test_name": "op_frem_double2_regular",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_frem_double2_regular"
+        "arguments": "op_frem_double2_regular",
+        "time_limit": 120
     },
     {
         "test_name": "op_fmod_double2_regular",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fmod_double2_regular"
+        "arguments": "op_fmod_double2_regular",
+        "time_limit": 120
     },
     {
         "test_name": "op_fadd_double2_fast",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fadd_double2_fast"
+        "arguments": "op_fadd_double2_fast",
+        "time_limit": 120
     },
     {
         "test_name": "op_fsub_double2_fast",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fsub_double2_fast"
+        "arguments": "op_fsub_double2_fast",
+        "time_limit": 120
     },
     {
         "test_name": "op_fmul_double2_fast",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fmul_double2_fast"
+        "arguments": "op_fmul_double2_fast",
+        "time_limit": 120
     },
     {
         "test_name": "op_fdiv_double2_fast",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fdiv_double2_fast"
+        "arguments": "op_fdiv_double2_fast",
+        "time_limit": 120
     },
     {
         "test_name": "op_frem_double2_fast",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_frem_double2_fast"
+        "arguments": "op_frem_double2_fast",
+        "time_limit": 120
     },
     {
         "test_name": "op_fmod_double2_fast",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fmod_double2_fast"
+        "arguments": "op_fmod_double2_fast",
+        "time_limit": 120
     },
     {
         "test_name": "op_fadd_half_regular",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fadd_half_regular"
+        "arguments": "op_fadd_half_regular",
+        "time_limit": 120
     },
     {
         "test_name": "op_fsub_half_regular",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fsub_half_regular"
+        "arguments": "op_fsub_half_regular",
+        "time_limit": 120
     },
     {
         "test_name": "op_fmul_half_regular",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fmul_half_regular"
+        "arguments": "op_fmul_half_regular",
+        "time_limit": 120
     },
     {
         "test_name": "op_fdiv_half_regular",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fdiv_half_regular"
+        "arguments": "op_fdiv_half_regular",
+        "time_limit": 120
     },
     {
         "test_name": "op_frem_half_regular",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_frem_half_regular"
+        "arguments": "op_frem_half_regular",
+        "time_limit": 120
     },
     {
         "test_name": "op_fmod_half_regular",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fmod_half_regular"
+        "arguments": "op_fmod_half_regular",
+        "time_limit": 120
     },
     {
         "test_name": "op_fadd_half_fast",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fadd_half_fast"
+        "arguments": "op_fadd_half_fast",
+        "time_limit": 120
     },
     {
         "test_name": "op_fsub_half_fast",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fsub_half_fast"
+        "arguments": "op_fsub_half_fast",
+        "time_limit": 120
     },
     {
         "test_name": "op_fmul_half_fast",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fmul_half_fast"
+        "arguments": "op_fmul_half_fast",
+        "time_limit": 120
     },
     {
         "test_name": "op_fdiv_half_fast",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fdiv_half_fast"
+        "arguments": "op_fdiv_half_fast",
+        "time_limit": 120
     },
     {
         "test_name": "op_frem_half_fast",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_frem_half_fast"
+        "arguments": "op_frem_half_fast",
+        "time_limit": 120
     },
     {
         "test_name": "op_fmod_half_fast",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_fmod_half_fast"
+        "arguments": "op_fmod_half_fast",
+        "time_limit": 120
     },
     {
         "test_name": "function_none",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "function_none"
+        "arguments": "function_none",
+        "time_limit": 120
     },
     {
         "test_name": "function_inline",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "function_inline"
+        "arguments": "function_inline",
+        "time_limit": 120
     },
     {
         "test_name": "function_noinline",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "function_noinline"
+        "arguments": "function_noinline",
+        "time_limit": 120
     },
     {
         "test_name": "function_pure",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "function_pure"
+        "arguments": "function_pure",
+        "time_limit": 120
     },
     {
         "test_name": "function_const",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "function_const"
+        "arguments": "function_const",
+        "time_limit": 120
     },
     {
         "test_name": "function_pure_ptr",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "function_pure_ptr"
+        "arguments": "function_pure_ptr",
+        "time_limit": 120
     },
     {
         "test_name": "op_lifetime_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_lifetime_simple"
+        "arguments": "op_lifetime_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_loop_merge_branch_none",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_loop_merge_branch_none"
+        "arguments": "op_loop_merge_branch_none",
+        "time_limit": 120
     },
     {
         "test_name": "op_loop_merge_branch_unroll",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_loop_merge_branch_unroll"
+        "arguments": "op_loop_merge_branch_unroll",
+        "time_limit": 120
     },
     {
         "test_name": "op_loop_merge_branch_dont_unroll",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_loop_merge_branch_dont_unroll"
+        "arguments": "op_loop_merge_branch_dont_unroll",
+        "time_limit": 120
     },
     {
         "test_name": "op_loop_merge_branch_conditional_none",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_loop_merge_branch_conditional_none"
+        "arguments": "op_loop_merge_branch_conditional_none",
+        "time_limit": 120
     },
     {
         "test_name": "op_loop_merge_branch_conditional_unroll",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_loop_merge_branch_conditional_unroll"
+        "arguments": "op_loop_merge_branch_conditional_unroll",
+        "time_limit": 120
     },
     {
         "test_name": "op_loop_merge_branch_conditional_dont_unroll",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_loop_merge_branch_conditional_dont_unroll"
+        "arguments": "op_loop_merge_branch_conditional_dont_unroll",
+        "time_limit": 120
     },
     {
         "test_name": "op_neg_float",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_neg_float"
+        "arguments": "op_neg_float",
+        "time_limit": 120
     },
     {
         "test_name": "op_neg_double",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_neg_double"
+        "arguments": "op_neg_double",
+        "time_limit": 120
     },
     {
         "test_name": "op_neg_int",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_neg_int"
+        "arguments": "op_neg_int",
+        "time_limit": 120
     },
     {
         "test_name": "op_neg_long",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_neg_long"
+        "arguments": "op_neg_long",
+        "time_limit": 120
     },
     {
         "test_name": "op_not_int",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_not_int"
+        "arguments": "op_not_int",
+        "time_limit": 120
     },
     {
         "test_name": "op_not_long",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_not_long"
+        "arguments": "op_not_long",
+        "time_limit": 120
     },
     {
         "test_name": "op_neg_short",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_neg_short"
+        "arguments": "op_neg_short",
+        "time_limit": 120
     },
     {
         "test_name": "op_not_short",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_not_short"
+        "arguments": "op_not_short",
+        "time_limit": 120
     },
     {
         "test_name": "op_neg_float4",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_neg_float4"
+        "arguments": "op_neg_float4",
+        "time_limit": 120
     },
     {
         "test_name": "op_neg_int4",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_neg_int4"
+        "arguments": "op_neg_int4",
+        "time_limit": 120
     },
     {
         "test_name": "op_not_int4",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_not_int4"
+        "arguments": "op_not_int4",
+        "time_limit": 120
     },
     {
         "test_name": "op_type_opaque_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_type_opaque_simple"
+        "arguments": "op_type_opaque_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_phi_2_blocks",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_phi_2_blocks"
+        "arguments": "op_phi_2_blocks",
+        "time_limit": 120
     },
     {
         "test_name": "op_phi_3_blocks",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_phi_3_blocks"
+        "arguments": "op_phi_3_blocks",
+        "time_limit": 120
     },
     {
         "test_name": "op_phi_4_blocks",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_phi_4_blocks"
+        "arguments": "op_phi_4_blocks",
+        "time_limit": 120
     },
     {
         "test_name": "op_selection_merge_if_none",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_selection_merge_if_none"
+        "arguments": "op_selection_merge_if_none",
+        "time_limit": 120
     },
     {
         "test_name": "op_selection_merge_if_flatten",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_selection_merge_if_flatten"
+        "arguments": "op_selection_merge_if_flatten",
+        "time_limit": 120
     },
     {
         "test_name": "op_selection_merge_if_dont_flatten",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_selection_merge_if_dont_flatten"
+        "arguments": "op_selection_merge_if_dont_flatten",
+        "time_limit": 120
     },
     {
         "test_name": "op_selection_merge_swith_none",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_selection_merge_swith_none"
+        "arguments": "op_selection_merge_swith_none",
+        "time_limit": 120
     },
     {
         "test_name": "op_selection_merge_swith_flatten",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_selection_merge_swith_flatten"
+        "arguments": "op_selection_merge_swith_flatten",
+        "time_limit": 120
     },
     {
         "test_name": "op_selection_merge_swith_dont_flatten",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_selection_merge_swith_dont_flatten"
+        "arguments": "op_selection_merge_swith_dont_flatten",
+        "time_limit": 120
     },
     {
         "test_name": "op_spec_constant_uint_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_spec_constant_uint_simple"
+        "arguments": "op_spec_constant_uint_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_spec_constant_uchar_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_spec_constant_uchar_simple"
+        "arguments": "op_spec_constant_uchar_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_spec_constant_ushort_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_spec_constant_ushort_simple"
+        "arguments": "op_spec_constant_ushort_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_spec_constant_ulong_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_spec_constant_ulong_simple"
+        "arguments": "op_spec_constant_ulong_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_spec_constant_float_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_spec_constant_float_simple"
+        "arguments": "op_spec_constant_float_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_spec_constant_half_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_spec_constant_half_simple"
+        "arguments": "op_spec_constant_half_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_spec_constant_double_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_spec_constant_double_simple"
+        "arguments": "op_spec_constant_double_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_spec_constant_true_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_spec_constant_true_simple"
+        "arguments": "op_spec_constant_true_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_spec_constant_false_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_spec_constant_false_simple"
+        "arguments": "op_spec_constant_false_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_undef_true_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_undef_true_simple"
+        "arguments": "op_undef_true_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_undef_false_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_undef_false_simple"
+        "arguments": "op_undef_false_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_undef_int_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_undef_int_simple"
+        "arguments": "op_undef_int_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_undef_uint_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_undef_uint_simple"
+        "arguments": "op_undef_uint_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_undef_char_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_undef_char_simple"
+        "arguments": "op_undef_char_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_undef_uchar_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_undef_uchar_simple"
+        "arguments": "op_undef_uchar_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_undef_ushort_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_undef_ushort_simple"
+        "arguments": "op_undef_ushort_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_undef_long_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_undef_long_simple"
+        "arguments": "op_undef_long_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_undef_ulong_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_undef_ulong_simple"
+        "arguments": "op_undef_ulong_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_undef_short_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_undef_short_simple"
+        "arguments": "op_undef_short_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_undef_float_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_undef_float_simple"
+        "arguments": "op_undef_float_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_undef_double_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_undef_double_simple"
+        "arguments": "op_undef_double_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_undef_int4_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_undef_int4_simple"
+        "arguments": "op_undef_int4_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_undef_int3_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_undef_int3_simple"
+        "arguments": "op_undef_int3_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_undef_struct_int_float_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_undef_struct_int_float_simple"
+        "arguments": "op_undef_struct_int_float_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_undef_struct_int_char_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_undef_struct_int_char_simple"
+        "arguments": "op_undef_struct_int_char_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_undef_struct_struct_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_undef_struct_struct_simple"
+        "arguments": "op_undef_struct_struct_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_undef_half_simple",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_undef_half_simple"
+        "arguments": "op_undef_half_simple",
+        "time_limit": 120
     },
     {
         "test_name": "op_vector_int4_extract",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_vector_int4_extract"
+        "arguments": "op_vector_int4_extract",
+        "time_limit": 120
     },
     {
         "test_name": "op_vector_float4_extract",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_vector_float4_extract"
+        "arguments": "op_vector_float4_extract",
+        "time_limit": 120
     },
     {
         "test_name": "op_vector_long2_extract",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_vector_long2_extract"
+        "arguments": "op_vector_long2_extract",
+        "time_limit": 120
     },
     {
         "test_name": "op_vector_double2_extract",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_vector_double2_extract"
+        "arguments": "op_vector_double2_extract",
+        "time_limit": 120
     },
     {
         "test_name": "op_vector_char16_extract",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_vector_char16_extract"
+        "arguments": "op_vector_char16_extract",
+        "time_limit": 120
     },
     {
         "test_name": "op_vector_int4_insert",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_vector_int4_insert"
+        "arguments": "op_vector_int4_insert",
+        "time_limit": 120
     },
     {
         "test_name": "op_vector_float4_insert",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_vector_float4_insert"
+        "arguments": "op_vector_float4_insert",
+        "time_limit": 120
     },
     {
         "test_name": "op_vector_long2_insert",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_vector_long2_insert"
+        "arguments": "op_vector_long2_insert",
+        "time_limit": 120
     },
     {
         "test_name": "op_vector_double2_insert",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_vector_double2_insert"
+        "arguments": "op_vector_double2_insert",
+        "time_limit": 120
     },
     {
         "test_name": "op_vector_char16_insert",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_vector_char16_insert"
+        "arguments": "op_vector_char16_insert",
+        "time_limit": 120
     },
     {
         "test_name": "op_vector_times_scalar_float",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_vector_times_scalar_float"
+        "arguments": "op_vector_times_scalar_float",
+        "time_limit": 120
     },
     {
         "test_name": "op_vector_times_scalar_double",
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
-        "arguments": "op_vector_times_scalar_double"
+        "arguments": "op_vector_times_scalar_double",
+        "time_limit": 120
     },
     {
         "test_name": "acos",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "acos -m -s -v"
+        "arguments": "acos -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "acosh",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "acosh -m -s -v"
+        "arguments": "acosh -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "acospi",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "acospi -m -s -v"
+        "arguments": "acospi -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "add",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "add -m -s -v"
+        "arguments": "add -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "asin",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "asin -m -s -v"
+        "arguments": "asin -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "asinh",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "asinh -m -s -v"
+        "arguments": "asinh -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "asinpi",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "asinpi -m -s -v"
+        "arguments": "asinpi -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "assignment",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "assignment -m -s -v"
+        "arguments": "assignment -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "atan",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "atan -m -s -v"
+        "arguments": "atan -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "atan2",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "atan2 -m -s -v"
+        "arguments": "atan2 -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "atan2pi",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "atan2pi -m -s -v"
+        "arguments": "atan2pi -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "atanh",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "atanh -m -s -v"
+        "arguments": "atanh -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "atanpi",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "atanpi -m -s -v"
+        "arguments": "atanpi -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "cbrt",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "cbrt -m -s -v"
+        "arguments": "cbrt -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "ceil",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "ceil -m -s -v"
+        "arguments": "ceil -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "copysign",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "copysign -m -s -v"
+        "arguments": "copysign -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "cos",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "cos -m -s -v"
+        "arguments": "cos -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "cosh",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "cosh -m -s -v"
+        "arguments": "cosh -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "cospi",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "cospi -m -s -v"
+        "arguments": "cospi -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "divide",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "divide -m -s -v"
+        "arguments": "divide -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "divide_cr",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "divide_cr -m -s -v"
+        "arguments": "divide_cr -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "exp",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "exp -m -s -v"
+        "arguments": "exp -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "exp10",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "exp10 -m -s -v"
+        "arguments": "exp10 -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "exp2",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "exp2 -m -s -v"
+        "arguments": "exp2 -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "expm1",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "expm1 -m -s -v"
+        "arguments": "expm1 -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "fabs",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "fabs -m -s -v"
+        "arguments": "fabs -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "fdim",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "fdim -m -s -v"
+        "arguments": "fdim -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "floor",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "floor -m -s -v"
+        "arguments": "floor -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "fma",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "fma -m -s -v"
+        "arguments": "fma -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "fmax",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "fmax -m -s -v"
+        "arguments": "fmax -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "fmin",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "fmin -m -s -v"
+        "arguments": "fmin -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "fmod",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "fmod -m -s -v"
+        "arguments": "fmod -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "fract",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "fract -m -s -v"
+        "arguments": "fract -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "frexp",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "frexp -m -s -v"
+        "arguments": "frexp -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "half_cos",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "half_cos -m -s -v"
+        "arguments": "half_cos -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "half_divide",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "half_divide -m -s -v"
+        "arguments": "half_divide -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "half_exp",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "half_exp -m -s -v"
+        "arguments": "half_exp -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "half_exp10",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "half_exp10 -m -s -v"
+        "arguments": "half_exp10 -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "half_exp2",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "half_exp2 -m -s -v"
+        "arguments": "half_exp2 -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "half_log",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "half_log -m -s -v"
+        "arguments": "half_log -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "half_log10",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "half_log10 -m -s -v"
+        "arguments": "half_log10 -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "half_log2",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "half_log2 -m -s -v"
+        "arguments": "half_log2 -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "half_powr",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "half_powr -m -s -v"
+        "arguments": "half_powr -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "half_recip",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "half_recip -m -s -v"
+        "arguments": "half_recip -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "half_rsqrt",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "half_rsqrt -m -s -v"
+        "arguments": "half_rsqrt -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "half_sin",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "half_sin -m -s -v"
+        "arguments": "half_sin -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "half_sqrt",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "half_sqrt -m -s -v"
+        "arguments": "half_sqrt -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "half_tan",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "half_tan -m -s -v"
+        "arguments": "half_tan -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "hypot",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "hypot -m -s -v"
+        "arguments": "hypot -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "ilogb",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "ilogb -m -s -v"
+        "arguments": "ilogb -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "isequal",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "isequal -m -s -v"
+        "arguments": "isequal -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "isfinite",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "isfinite -m -s -v"
+        "arguments": "isfinite -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "isgreater",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "isgreater -m -s -v"
+        "arguments": "isgreater -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "isgreaterequal",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "isgreaterequal -m -s -v"
+        "arguments": "isgreaterequal -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "isinf",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "isinf -m -s -v"
+        "arguments": "isinf -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "isless",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "isless -m -s -v"
+        "arguments": "isless -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "islessequal",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "islessequal -m -s -v"
+        "arguments": "islessequal -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "islessgreater",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "islessgreater -m -s -v"
+        "arguments": "islessgreater -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "isnan",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "isnan -m -s -v"
+        "arguments": "isnan -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "isnormal",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "isnormal -m -s -v"
+        "arguments": "isnormal -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "isnotequal",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "isnotequal -m -s -v"
+        "arguments": "isnotequal -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "isordered",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "isordered -m -s -v"
+        "arguments": "isordered -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "isunordered",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "isunordered -m -s -v"
+        "arguments": "isunordered -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "ldexp",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "ldexp -m -s -v"
+        "arguments": "ldexp -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "lgamma",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "lgamma -m -s -v"
+        "arguments": "lgamma -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "lgamma_r",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "lgamma_r -m -s -v"
+        "arguments": "lgamma_r -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "log",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "log -m -s -v"
+        "arguments": "log -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "log10",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "log10 -m -s -v"
+        "arguments": "log10 -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "log1p",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "log1p -m -s -v"
+        "arguments": "log1p -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "log2",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "log2 -m -s -v"
+        "arguments": "log2 -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "logb",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "logb -m -s -v"
+        "arguments": "logb -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "mad",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "mad -m -s -v"
+        "arguments": "mad -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "maxmag",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "maxmag -m -s -v"
+        "arguments": "maxmag -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "minmag",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "minmag -m -s -v"
+        "arguments": "minmag -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "modf",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "modf -m -s -v"
+        "arguments": "modf -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "multiply",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "multiply -m -s -v"
+        "arguments": "multiply -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "nan",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "nan -m -s -v"
+        "arguments": "nan -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "nextafter",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "nextafter -m -s -v"
+        "arguments": "nextafter -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "not",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "not -m -s -v"
+        "arguments": "not -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "pow",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "pow -m -s -v"
+        "arguments": "pow -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "pown",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "pown -m -s -v"
+        "arguments": "pown -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "powr",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "powr -m -s -v"
+        "arguments": "powr -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "remainder",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "remainder -m -s -v"
+        "arguments": "remainder -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "remquo",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "remquo -m -s -v"
+        "arguments": "remquo -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "rint",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "rint -m -s -v"
+        "arguments": "rint -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "rootn",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "rootn -m -s -v"
+        "arguments": "rootn -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "round",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "round -m -s -v"
+        "arguments": "round -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "rsqrt",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "rsqrt -m -s -v"
+        "arguments": "rsqrt -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "signbit",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "signbit -m -s -v"
+        "arguments": "signbit -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "sin",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "sin -m -s -v"
+        "arguments": "sin -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "sincos",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "sincos -m -s -v"
+        "arguments": "sincos -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "sinh",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "sinh -m -s -v"
+        "arguments": "sinh -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "sinpi",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "sinpi -m -s -v"
+        "arguments": "sinpi -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "sqrt",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "sqrt -m -s -v"
+        "arguments": "sqrt -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "sqrt_cr",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "sqrt_cr -m -s -v"
+        "arguments": "sqrt_cr -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "subtract",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "subtract -m -s -v"
+        "arguments": "subtract -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "tan",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "tan -m -s -v"
+        "arguments": "tan -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "tanh",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "tanh -m -s -v"
+        "arguments": "tanh -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "tanpi",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "tanpi -m -s -v"
+        "arguments": "tanpi -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "trunc",
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
-        "arguments": "trunc -m -s -v"
+        "arguments": "trunc -m -s -v",
+        "time_limit": 480
     },
     {
         "test_name": "svm_byte_granularity",
         "test_category": "SVM",
         "executable_path": "test_conformance/SVM/bin/test_svm",
-        "arguments": "svm_byte_granularity"
+        "arguments": "svm_byte_granularity",
+        "time_limit": 120
     },
     {
         "test_name": "svm_set_kernel_exec_info_svm_ptrs",
         "test_category": "SVM",
         "executable_path": "test_conformance/SVM/bin/test_svm",
-        "arguments": "svm_set_kernel_exec_info_svm_ptrs"
+        "arguments": "svm_set_kernel_exec_info_svm_ptrs",
+        "time_limit": 120
     },
     {
         "test_name": "svm_fine_grain_memory_consistency",
         "test_category": "SVM",
         "executable_path": "test_conformance/SVM/bin/test_svm",
-        "arguments": "svm_fine_grain_memory_consistency"
+        "arguments": "svm_fine_grain_memory_consistency",
+        "time_limit": 120
     },
     {
         "test_name": "svm_fine_grain_sync_buffers",
         "test_category": "SVM",
         "executable_path": "test_conformance/SVM/bin/test_svm",
-        "arguments": "svm_fine_grain_sync_buffers"
+        "arguments": "svm_fine_grain_sync_buffers",
+        "time_limit": 120
     },
     {
         "test_name": "svm_shared_address_space_fine_grain",
         "test_category": "SVM",
         "executable_path": "test_conformance/SVM/bin/test_svm",
-        "arguments": "svm_shared_address_space_fine_grain"
+        "arguments": "svm_shared_address_space_fine_grain",
+        "time_limit": 120
     },
     {
         "test_name": "svm_shared_sub_buffers",
         "test_category": "SVM",
         "executable_path": "test_conformance/SVM/bin/test_svm",
-        "arguments": "svm_shared_sub_buffers"
+        "arguments": "svm_shared_sub_buffers",
+        "time_limit": 120
     },
     {
         "test_name": "svm_shared_address_space_fine_grain_buffers",
         "test_category": "SVM",
         "executable_path": "test_conformance/SVM/bin/test_svm",
-        "arguments": "svm_shared_address_space_fine_grain_buffers"
+        "arguments": "svm_shared_address_space_fine_grain_buffers",
+        "time_limit": 120
     },
     {
         "test_name": "svm_allocate_shared_buffer",
         "test_category": "SVM",
         "executable_path": "test_conformance/SVM/bin/test_svm",
-        "arguments": "svm_allocate_shared_buffer"
+        "arguments": "svm_allocate_shared_buffer",
+        "time_limit": 120
     },
     {
         "test_name": "svm_shared_address_space_coarse_grain_old_api",
         "test_category": "SVM",
         "executable_path": "test_conformance/SVM/bin/test_svm",
-        "arguments": "svm_shared_address_space_coarse_grain_old_api"
+        "arguments": "svm_shared_address_space_coarse_grain_old_api",
+        "time_limit": 120
     },
     {
         "test_name": "svm_shared_address_space_coarse_grain_new_api",
         "test_category": "SVM",
         "executable_path": "test_conformance/SVM/bin/test_svm",
-        "arguments": "svm_shared_address_space_coarse_grain_new_api"
+        "arguments": "svm_shared_address_space_coarse_grain_new_api",
+        "time_limit": 120
     },
     {
         "test_name": "svm_cross_buffer_pointers_coarse_grain",
         "test_category": "SVM",
         "executable_path": "test_conformance/SVM/bin/test_svm",
-        "arguments": "svm_cross_buffer_pointers_coarse_grain"
+        "arguments": "svm_cross_buffer_pointers_coarse_grain",
+        "time_limit": 120
     },
     {
         "test_name": "svm_pointer_passing",
         "test_category": "SVM",
         "executable_path": "test_conformance/SVM/bin/test_svm",
-        "arguments": "svm_pointer_passing"
+        "arguments": "svm_pointer_passing",
+        "time_limit": 120
     },
     {
         "test_name": "svm_enqueue_api",
         "test_category": "SVM",
         "executable_path": "test_conformance/SVM/bin/test_svm",
-        "arguments": "svm_enqueue_api"
+        "arguments": "svm_enqueue_api",
+        "time_limit": 120
     },
     {
         "test_name": "svm_migrate",
         "test_category": "SVM",
         "executable_path": "test_conformance/SVM/bin/test_svm",
-        "arguments": "svm_migrate"
+        "arguments": "svm_migrate",
+        "time_limit": 120
     },
     {
         "test_name": "1D",
         "test_category": "clCopyImage",
         "executable_path": "test_conformance/images/clCopyImage/bin/test_cl_copy_images",
-        "arguments": "1D"
+        "arguments": "1D",
+        "time_limit": 120
     },
     {
         "test_name": "2D",
         "test_category": "clCopyImage",
         "executable_path": "test_conformance/images/clCopyImage/bin/test_cl_copy_images",
-        "arguments": "2D"
+        "arguments": "2D",
+        "time_limit": 120
     },
     {
         "test_name": "3D",
         "test_category": "clCopyImage",
         "executable_path": "test_conformance/images/clCopyImage/bin/test_cl_copy_images",
-        "arguments": "3D"
+        "arguments": "3D",
+        "time_limit": 120
     },
     {
         "test_name": "1Darray",
         "test_category": "clCopyImage",
         "executable_path": "test_conformance/images/clCopyImage/bin/test_cl_copy_images",
-        "arguments": "1Darray"
+        "arguments": "1Darray",
+        "time_limit": 120
     },
     {
         "test_name": "2Darray",
         "test_category": "clCopyImage",
         "executable_path": "test_conformance/images/clCopyImage/bin/test_cl_copy_images",
-        "arguments": "2Darray"
+        "arguments": "2Darray",
+        "time_limit": 120
     },
     {
         "test_name": "2Dto3D",
         "test_category": "clCopyImage",
         "executable_path": "test_conformance/images/clCopyImage/bin/test_cl_copy_images",
-        "arguments": "2Dto3D"
+        "arguments": "2Dto3D",
+        "time_limit": 120
     },
     {
         "test_name": "3Dto2D",
         "test_category": "clCopyImage",
         "executable_path": "test_conformance/images/clCopyImage/bin/test_cl_copy_images",
-        "arguments": "3Dto2D"
+        "arguments": "3Dto2D",
+        "time_limit": 120
     },
     {
         "test_name": "2Darrayto2D",
         "test_category": "clCopyImage",
         "executable_path": "test_conformance/images/clCopyImage/bin/test_cl_copy_images",
-        "arguments": "2Darrayto2D"
+        "arguments": "2Darrayto2D",
+        "time_limit": 120
     },
     {
         "test_name": "2Dto2Darray",
         "test_category": "clCopyImage",
         "executable_path": "test_conformance/images/clCopyImage/bin/test_cl_copy_images",
-        "arguments": "2Dto2Darray"
+        "arguments": "2Dto2Darray",
+        "time_limit": 120
     },
     {
         "test_name": "2Darrayto3D",
         "test_category": "clCopyImage",
         "executable_path": "test_conformance/images/clCopyImage/bin/test_cl_copy_images",
-        "arguments": "2Darrayto3D"
+        "arguments": "2Darrayto3D",
+        "time_limit": 120
     },
     {
         "test_name": "3Dto2Darray",
         "test_category": "clCopyImage",
         "executable_path": "test_conformance/images/clCopyImage/bin/test_cl_copy_images",
-        "arguments": "3Dto2Darray"
+        "arguments": "3Dto2Darray",
+        "time_limit": 120
     },
     {
         "test_name": "1D",
         "test_category": "clFillImage",
         "executable_path": "test_conformance/images/clFillImage/bin/test_cl_fill_images",
-        "arguments": "1D"
+        "arguments": "1D",
+        "time_limit": 120
     },
     {
         "test_name": "2D",
         "test_category": "clFillImage",
         "executable_path": "test_conformance/images/clFillImage/bin/test_cl_fill_images",
-        "arguments": "2D"
+        "arguments": "2D",
+        "time_limit": 120
     },
     {
         "test_name": "3D",
         "test_category": "clFillImage",
         "executable_path": "test_conformance/images/clFillImage/bin/test_cl_fill_images",
-        "arguments": "3D"
+        "arguments": "3D",
+        "time_limit": 120
     },
     {
         "test_name": "1Darray",
         "test_category": "clFillImage",
         "executable_path": "test_conformance/images/clFillImage/bin/test_cl_fill_images",
-        "arguments": "1Darray"
+        "arguments": "1Darray",
+        "time_limit": 120
     },
     {
         "test_name": "2Darray",
         "test_category": "clFillImage",
         "executable_path": "test_conformance/images/clFillImage/bin/test_cl_fill_images",
-        "arguments": "2Darray"
+        "arguments": "2Darray",
+        "time_limit": 120
     },
     {
         "test_name": "1D",
         "test_category": "clGetInfo",
         "executable_path": "test_conformance/images/clGetInfo/bin/test_cl_get_info",
-        "arguments": "1D"
+        "arguments": "1D",
+        "time_limit": 120
     },
     {
         "test_name": "2D",
         "test_category": "clGetInfo",
         "executable_path": "test_conformance/images/clGetInfo/bin/test_cl_get_info",
-        "arguments": "2D"
+        "arguments": "2D",
+        "time_limit": 120
     },
     {
         "test_name": "3D",
         "test_category": "clGetInfo",
         "executable_path": "test_conformance/images/clGetInfo/bin/test_cl_get_info",
-        "arguments": "3D"
+        "arguments": "3D",
+        "time_limit": 120
     },
     {
         "test_name": "1Darray",
         "test_category": "clGetInfo",
         "executable_path": "test_conformance/images/clGetInfo/bin/test_cl_get_info",
-        "arguments": "1Darray"
+        "arguments": "1Darray",
+        "time_limit": 120
     },
     {
         "test_name": "2Darray",
         "test_category": "clGetInfo",
         "executable_path": "test_conformance/images/clGetInfo/bin/test_cl_get_info",
-        "arguments": "2Darray"
+        "arguments": "2Darray",
+        "time_limit": 120
     },
     {
         "test_name": "1D",
         "test_category": "clReadWriteImage",
         "executable_path": "test_conformance/images/clReadWriteImage/bin/test_cl_read_write_images",
-        "arguments": "1D"
+        "arguments": "1D",
+        "time_limit": 120
     },
     {
         "test_name": "2D",
         "test_category": "clReadWriteImage",
         "executable_path": "test_conformance/images/clReadWriteImage/bin/test_cl_read_write_images",
-        "arguments": "2D"
+        "arguments": "2D",
+        "time_limit": 120
     },
     {
         "test_name": "3D",
         "test_category": "clReadWriteImage",
         "executable_path": "test_conformance/images/clReadWriteImage/bin/test_cl_read_write_images",
-        "arguments": "3D"
+        "arguments": "3D",
+        "time_limit": 120
     },
     {
         "test_name": "1Darray",
         "test_category": "clReadWriteImage",
         "executable_path": "test_conformance/images/clReadWriteImage/bin/test_cl_read_write_images",
-        "arguments": "1Darray"
+        "arguments": "1Darray",
+        "time_limit": 120
     },
     {
         "test_name": "2Darray",
         "test_category": "clReadWriteImage",
         "executable_path": "test_conformance/images/clReadWriteImage/bin/test_cl_read_write_images",
-        "arguments": "2Darray"
+        "arguments": "2Darray",
+        "time_limit": 120
     },
     {
         "test_name": "1D",
         "test_category": "kernel_image_methods",
         "executable_path": "test_conformance/images/kernel_image_methods/bin/test_kernel_image_methods",
-        "arguments": "1D"
+        "arguments": "1D",
+        "time_limit": 120
     },
     {
         "test_name": "2D",
         "test_category": "kernel_image_methods",
         "executable_path": "test_conformance/images/kernel_image_methods/bin/test_kernel_image_methods",
-        "arguments": "2D"
+        "arguments": "2D",
+        "time_limit": 120
     },
     {
         "test_name": "3D",
         "test_category": "kernel_image_methods",
         "executable_path": "test_conformance/images/kernel_image_methods/bin/test_kernel_image_methods",
-        "arguments": "3D"
+        "arguments": "3D",
+        "time_limit": 120
     },
     {
         "test_name": "1Darray",
         "test_category": "kernel_image_methods",
         "executable_path": "test_conformance/images/kernel_image_methods/bin/test_kernel_image_methods",
-        "arguments": "1Darray"
+        "arguments": "1Darray",
+        "time_limit": 120
     },
     {
         "test_name": "2Darray",
         "test_category": "kernel_image_methods",
         "executable_path": "test_conformance/images/kernel_image_methods/bin/test_kernel_image_methods",
-        "arguments": "2Darray"
+        "arguments": "2Darray",
+        "time_limit": 120
     },
     {
         "test_name": "1D",
         "test_category": "kernel_read_write",
         "executable_path": "test_conformance/images/kernel_read_write/bin/test_image_streams",
-        "arguments": "1D"
+        "arguments": "1D",
+        "time_limit": 120
     },
     {
         "test_name": "2D",
         "test_category": "kernel_read_write",
         "executable_path": "test_conformance/images/kernel_read_write/bin/test_image_streams",
-        "arguments": "2D"
+        "arguments": "2D",
+        "time_limit": 120
     },
     {
         "test_name": "3D",
         "test_category": "kernel_read_write",
         "executable_path": "test_conformance/images/kernel_read_write/bin/test_image_streams",
-        "arguments": "3D"
+        "arguments": "3D",
+        "time_limit": 120
     },
     {
         "test_name": "1Darray",
         "test_category": "kernel_read_write",
         "executable_path": "test_conformance/images/kernel_read_write/bin/test_image_streams",
-        "arguments": "1Darray"
+        "arguments": "1Darray",
+        "time_limit": 120
     },
     {
         "test_name": "2Darray",
         "test_category": "kernel_read_write",
         "executable_path": "test_conformance/images/kernel_read_write/bin/test_image_streams",
-        "arguments": "2Darray"
+        "arguments": "2Darray",
+        "time_limit": 120
     },
     {
         "test_name": "1D",
         "test_category": "samplerlessReads",
         "executable_path": "test_conformance/images/samplerlessReads/bin/test_samplerless_reads",
-        "arguments": "1D"
+        "arguments": "1D",
+        "time_limit": 120
     },
     {
         "test_name": "2D",
         "test_category": "samplerlessReads",
         "executable_path": "test_conformance/images/samplerlessReads/bin/test_samplerless_reads",
-        "arguments": "2D"
+        "arguments": "2D",
+        "time_limit": 120
     },
     {
         "test_name": "3D",
         "test_category": "samplerlessReads",
         "executable_path": "test_conformance/images/samplerlessReads/bin/test_samplerless_reads",
-        "arguments": "3D"
+        "arguments": "3D",
+        "time_limit": 120
     },
     {
         "test_name": "1Darray",
         "test_category": "samplerlessReads",
         "executable_path": "test_conformance/images/samplerlessReads/bin/test_samplerless_reads",
-        "arguments": "1Darray"
+        "arguments": "1Darray",
+        "time_limit": 120
     },
     {
         "test_name": "2Darray",

--- a/tester/runner.py
+++ b/tester/runner.py
@@ -171,6 +171,7 @@ def _run_cts_test(test_category: str, test_name: str) -> CTSResult:
     """
     test_executable = get_cts_test_executable_absolute_path(test_category, test_name)
     test_arguments = get_cts_test_arguments(test_category, test_name)
+    test_time_limit = get_cts_test_time_limit(test_category, test_name)
 
     # Prepare a temporary directory for dump files.
     dumps_directory_name = (
@@ -195,7 +196,7 @@ def _run_cts_test(test_category: str, test_name: str) -> CTSResult:
             stderr=subprocess.PIPE,
             cwd=os.path.dirname(test_executable),
             env=environment,
-            timeout=2 * 60 * 60,
+            timeout=test_time_limit * 60,
         )
         passing = run_result.returncode == 0 and (
             "PASSED test." in run_result.stdout.decode("utf-8")
@@ -207,8 +208,8 @@ def _run_cts_test(test_category: str, test_name: str) -> CTSResult:
     except subprocess.TimeoutExpired:
         passing = False
         timedout = True
-        standard_output = "Test timed out after 2 hours"
-        standard_error = "Test timed out after 2 hours"
+        standard_output = f"Test timed out after {test_time_limit} minutes"
+        standard_error = f"Test timed out after {test_time_limit} minutes"
     end_time = datetime.now()
     # Testing ended.
 


### PR DESCRIPTION
This changes adds an option to specify time limit for each CTS test. All CTS tests have a default 2 h time limit set, except for math_brute_force tests with 8 h time limit.

Closes #3 