### PR TITLE
[tester] Add environment flags for each CTS test

### DIFF
--- a/tester/config.py
+++ b/tester/config.py
@@ -77,6 +77,18 @@ def get_cts_test_arguments(test_category: str, test_name: str) -> List[str]:
     raise KeyError(f"Test {test_category}/{test_name} definition was not found")
 
 
+def get_cts_test_environment(test_category: str, test_name: str) -> List[str]:
+    """
+    Get a list of environment variables for the given OpenCL CTS test.
+    """
+    test_list = get_cts_test_list()
+    for test in test_list:
+        if test["test_category"] == test_category and test["test_name"] == test_name:
+            return test["environment"].split()
+
+    raise KeyError(f"Test {test_category}/{test_name} definition was not found")
+
+
 def get_cts_test_time_limit(test_category: str, test_name: str) -> int:
     """
     Get a the time limit for the given OpenCL CTS test.

--- a/tester/cts.json
+++ b/tester/cts.json
@@ -4,6 +4,7 @@
         "test_category": "allocations",
         "executable_path": "test_conformance/allocations/bin/test_allocations",
         "arguments": "buffer",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -11,6 +12,7 @@
         "test_category": "allocations",
         "executable_path": "test_conformance/allocations/bin/test_allocations",
         "arguments": "image2d_read",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -18,6 +20,7 @@
         "test_category": "allocations",
         "executable_path": "test_conformance/allocations/bin/test_allocations",
         "arguments": "image2d_write",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -25,6 +28,7 @@
         "test_category": "allocations",
         "executable_path": "test_conformance/allocations/bin/test_allocations",
         "arguments": "buffer_non_blocking",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -32,6 +36,7 @@
         "test_category": "allocations",
         "executable_path": "test_conformance/allocations/bin/test_allocations",
         "arguments": "image2d_read_non_blocking",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -39,6 +44,7 @@
         "test_category": "allocations",
         "executable_path": "test_conformance/allocations/bin/test_allocations",
         "arguments": "image2d_write_non_blocking",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -46,6 +52,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "get_platform_info",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -53,6 +60,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "get_sampler_info",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -60,6 +68,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "get_sampler_info_compatibility",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -67,6 +76,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "get_command_queue_info",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -74,6 +84,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "get_command_queue_info_compatibility",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -81,6 +92,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "get_context_info",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -88,6 +100,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "get_device_info",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -95,6 +108,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "enqueue_task",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -102,6 +116,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "binary_get",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -109,6 +124,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "binary_create",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -116,6 +132,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "kernel_required_group_size",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -123,6 +140,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "release_kernel_order",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -130,6 +148,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "release_during_execute",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -137,6 +156,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "load_single_kernel",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -144,6 +164,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "load_two_kernels",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -151,6 +172,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "load_two_kernels_in_one",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -158,6 +180,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "load_two_kernels_manually",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -165,6 +188,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "get_program_info_kernel_names",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -172,6 +196,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "get_kernel_arg_info",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -179,6 +204,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "create_kernels_in_program",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -186,6 +212,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "get_kernel_info",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -193,6 +220,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "kernel_private_memory_size",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -200,6 +228,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "execute_kernel_local_sizes",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -207,6 +236,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "set_kernel_arg_by_index",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -214,6 +244,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "set_kernel_arg_constant",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -221,6 +252,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "set_kernel_arg_struct_array",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -228,6 +260,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "kernel_global_constant",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -235,6 +268,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "kernel_attributes",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -242,6 +276,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "min_max_thread_dimensions",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -249,6 +284,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "min_max_work_items_sizes",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -256,6 +292,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "min_max_work_group_size",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -263,6 +300,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "min_max_read_image_args",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -270,6 +308,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "min_max_write_image_args",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -277,6 +316,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "min_max_mem_alloc_size",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -284,6 +324,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "min_max_image_2d_width",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -291,6 +332,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "min_max_image_2d_height",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -298,6 +340,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "min_max_image_3d_width",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -305,6 +348,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "min_max_image_3d_height",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -312,6 +356,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "min_max_image_3d_depth",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -319,6 +364,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "min_max_image_array_size",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -326,6 +372,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "min_max_image_buffer_size",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -333,6 +380,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "min_max_parameter_size",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -340,6 +388,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "min_max_samplers",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -347,6 +396,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "min_max_constant_buffer_size",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -354,6 +404,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "min_max_constant_args",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -361,6 +412,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "min_max_compute_units",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -368,6 +420,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "min_max_address_bits",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -375,6 +428,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "min_max_single_fp_config",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -382,6 +436,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "min_max_double_fp_config",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -389,6 +444,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "min_max_local_mem_size",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -396,6 +452,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "min_max_kernel_preferred_work_group_size_multiple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -403,6 +460,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "min_max_execution_capabilities",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -410,6 +468,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "min_max_queue_properties",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -417,6 +476,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "min_max_device_version",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -424,6 +484,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "min_max_language_version",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -431,6 +492,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "kernel_arg_changes",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -438,6 +500,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "kernel_arg_multi_setup_random",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -445,6 +508,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "native_kernel",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -452,6 +516,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "create_context_from_type",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -459,6 +524,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "platform_extensions",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -466,6 +532,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "get_platform_ids",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -473,6 +540,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "bool_type",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -480,6 +548,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "repeated_setup_cleanup",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -487,6 +556,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "retain_queue_single",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -494,6 +564,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "retain_queue_multiple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -501,6 +572,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "retain_mem_object_single",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -508,6 +580,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "retain_mem_object_multiple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -515,6 +588,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "retain_mem_object_set_kernel_arg",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -522,6 +596,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "min_data_type_align_size_alignment",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -529,6 +604,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "context_destructor_callback",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -536,6 +612,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "mem_object_destructor_callback",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -543,6 +620,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "null_buffer_arg",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -550,6 +628,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "get_buffer_info",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -557,6 +636,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "get_image2d_info",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -564,6 +644,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "get_image3d_info",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -571,6 +652,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "get_image1d_info",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -578,6 +660,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "get_image1d_array_info",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -585,6 +668,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "get_image2d_array_info",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -592,6 +676,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "queue_flush_on_release",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -599,6 +684,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "queue_hint",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -606,6 +692,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "queue_properties",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -613,6 +700,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "sub_group_dispatch",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -620,6 +708,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "clone_kernel",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -627,6 +716,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "zero_sized_enqueue",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -634,6 +724,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "buffer_properties_queries",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -641,6 +732,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "image_properties_queries",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -648,6 +740,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "queue_properties_queries",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -655,6 +748,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "pipe_properties_queries",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -662,6 +756,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "consistency_svm",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -669,6 +764,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "consistency_memory_model",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -676,6 +772,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "consistency_device_enqueue",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -683,6 +780,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "consistency_pipes",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -690,6 +788,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "consistency_progvar",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -697,6 +796,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "consistency_non_uniform_work_group",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -704,6 +804,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "consistency_read_write_images",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -711,6 +812,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "consistency_2d_image_from_buffer",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -718,6 +820,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "consistency_depth_images",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -725,6 +828,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "consistency_device_and_host_timer",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -732,6 +836,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "consistency_il_programs",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -739,6 +844,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "consistency_subgroups",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -746,6 +852,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "consistency_prog_ctor_dtor",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -753,6 +860,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "consistency_3d_image_writes",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -760,6 +868,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "min_image_formats",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -767,6 +876,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "negative_get_platform_info",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -774,6 +884,7 @@
         "test_category": "api",
         "executable_path": "test_conformance/api/bin/test_api",
         "arguments": "negative_get_platform_ids",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -781,6 +892,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "hostptr",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -788,6 +900,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "fpmath_float",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -795,6 +908,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "fpmath_float2",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -802,6 +916,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "fpmath_float4",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -809,6 +924,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "intmath_int",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -816,6 +932,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "intmath_int2",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -823,6 +940,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "intmath_int4",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -830,6 +948,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "intmath_long",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -837,6 +956,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "intmath_long2",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -844,6 +964,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "intmath_long4",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -851,6 +972,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "hiloeo",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -858,6 +980,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "if",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -865,6 +988,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "sizeof",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -872,6 +996,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "loop",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -879,6 +1004,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "pointer_cast",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -886,6 +1012,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "local_arg_def",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -893,6 +1020,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "local_kernel_def",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -900,6 +1028,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "local_kernel_scope",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -907,6 +1036,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "constant",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -914,6 +1044,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "constant_source",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -921,6 +1052,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "readimage",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -928,6 +1060,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "readimage_int16",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -935,6 +1068,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "readimage_fp32",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -942,6 +1076,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "writeimage",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -949,6 +1084,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "writeimage_int16",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -956,6 +1092,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "writeimage_fp32",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -963,6 +1100,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "mri_one",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -970,6 +1108,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "mri_multiple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -977,6 +1116,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "image_r8",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -984,6 +1124,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "barrier",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -991,6 +1132,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "wg_barrier",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -998,6 +1140,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "int2float",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1005,6 +1148,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "float2int",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1012,6 +1156,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "imagereadwrite",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1019,6 +1164,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "imagereadwrite3d",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1026,6 +1172,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "readimage3d",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1033,6 +1180,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "readimage3d_int16",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1040,6 +1188,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "readimage3d_fp32",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1047,6 +1196,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "bufferreadwriterect",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1054,6 +1204,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "arrayreadwrite",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1061,6 +1212,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "arraycopy",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1068,6 +1220,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "imagearraycopy",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1075,6 +1228,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "imagearraycopy3d",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1082,6 +1236,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "imagecopy",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1089,6 +1244,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "imagecopy3d",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1096,6 +1252,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "imagerandomcopy",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1103,6 +1260,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "arrayimagecopy",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1110,6 +1268,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "arrayimagecopy3d",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1117,6 +1276,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "imagenpot",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1124,6 +1284,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "vload_global",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1131,6 +1292,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "vload_local",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1138,6 +1300,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "vload_constant",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1145,6 +1308,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "vload_private",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1152,6 +1316,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "vstore_global",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1159,6 +1324,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "vstore_local",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1166,6 +1332,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "vstore_private",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1173,6 +1340,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "createkernelsinprogram",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1180,6 +1348,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "imagedim_pow2",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1187,6 +1356,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "imagedim_non_pow2",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1194,6 +1364,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "image_param",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1201,6 +1372,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "image_multipass_integer_coord",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1208,6 +1380,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "image_multipass_float_coord",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1215,6 +1388,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "explicit_s2v_char",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1222,6 +1396,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "explicit_s2v_uchar",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1229,6 +1404,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "explicit_s2v_short",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1236,6 +1412,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "explicit_s2v_ushort",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1243,6 +1420,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "explicit_s2v_int",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1250,6 +1428,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "explicit_s2v_uint",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1257,6 +1436,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "explicit_s2v_long",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1264,6 +1444,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "explicit_s2v_ulong",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1271,6 +1452,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "explicit_s2v_float",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1278,6 +1460,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "explicit_s2v_double",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1285,6 +1468,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "enqueue_map_buffer",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1292,6 +1476,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "enqueue_map_image",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1299,6 +1484,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "work_item_functions",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1306,6 +1492,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "astype",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1313,6 +1500,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "async_copy_global_to_local",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1320,6 +1508,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "async_copy_local_to_global",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1327,6 +1516,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "async_strided_copy_global_to_local",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1334,6 +1524,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "async_strided_copy_local_to_global",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1341,6 +1532,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "async_copy_global_to_local2D",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1348,6 +1540,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "async_copy_local_to_global2D",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1355,6 +1548,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "async_copy_global_to_local3D",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1362,6 +1556,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "async_copy_local_to_global3D",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1369,6 +1564,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "async_work_group_copy_fence_import_after_export_aliased_local",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1376,6 +1572,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "async_work_group_copy_fence_import_after_export_aliased_global",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1383,6 +1580,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "async_work_group_copy_fence_import_after_export_aliased_global_and_local",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1390,6 +1588,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "async_work_group_copy_fence_export_after_import_aliased_local",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1397,6 +1596,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "async_work_group_copy_fence_export_after_import_aliased_global",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1404,6 +1604,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "async_work_group_copy_fence_export_after_import_aliased_global_and_local",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1411,6 +1612,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "prefetch",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1418,6 +1620,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "kernel_call_kernel_function",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1425,6 +1628,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "host_numeric_constants",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1432,6 +1636,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "kernel_numeric_constants",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1439,6 +1644,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "kernel_limit_constants",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1446,6 +1652,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "kernel_preprocessor_macros",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1453,6 +1660,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "parameter_types",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1460,6 +1668,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "vector_creation",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1467,6 +1676,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "vector_swizzle",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1474,6 +1684,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "vec_type_hint",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1481,6 +1692,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "kernel_memory_alignment_local",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1488,6 +1700,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "kernel_memory_alignment_global",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1495,6 +1708,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "kernel_memory_alignment_constant",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1502,6 +1716,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "kernel_memory_alignment_private",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1509,6 +1724,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "progvar_prog_scope_misc",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1516,6 +1732,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "progvar_prog_scope_uninit",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1523,6 +1740,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "progvar_prog_scope_init",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1530,6 +1748,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "progvar_func_scope",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1537,6 +1756,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "global_work_offsets",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1544,6 +1764,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "get_global_offset",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1551,6 +1772,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "global_linear_id",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1558,6 +1780,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "local_linear_id",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1565,6 +1788,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "enqueued_local_size",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1572,6 +1796,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "simple_read_image_pitch",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1579,6 +1804,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "simple_write_image_pitch",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1586,6 +1812,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "get_linear_ids",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1593,6 +1820,7 @@
         "test_category": "basic",
         "executable_path": "test_conformance/basic/bin/test_basic",
         "arguments": "rw_image_access_qualifier",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1600,6 +1828,7 @@
         "test_category": "atomics",
         "executable_path": "test_conformance/atomics/bin/test_atomics",
         "arguments": "atomic_add",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1607,6 +1836,7 @@
         "test_category": "atomics",
         "executable_path": "test_conformance/atomics/bin/test_atomics",
         "arguments": "atomic_sub",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1614,6 +1844,7 @@
         "test_category": "atomics",
         "executable_path": "test_conformance/atomics/bin/test_atomics",
         "arguments": "atomic_xchg",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1621,6 +1852,7 @@
         "test_category": "atomics",
         "executable_path": "test_conformance/atomics/bin/test_atomics",
         "arguments": "atomic_min",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1628,6 +1860,7 @@
         "test_category": "atomics",
         "executable_path": "test_conformance/atomics/bin/test_atomics",
         "arguments": "atomic_max",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1635,6 +1868,7 @@
         "test_category": "atomics",
         "executable_path": "test_conformance/atomics/bin/test_atomics",
         "arguments": "atomic_inc",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1642,6 +1876,7 @@
         "test_category": "atomics",
         "executable_path": "test_conformance/atomics/bin/test_atomics",
         "arguments": "atomic_dec",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1649,6 +1884,7 @@
         "test_category": "atomics",
         "executable_path": "test_conformance/atomics/bin/test_atomics",
         "arguments": "atomic_cmpxchg",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1656,6 +1892,7 @@
         "test_category": "atomics",
         "executable_path": "test_conformance/atomics/bin/test_atomics",
         "arguments": "atomic_and",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1663,6 +1900,7 @@
         "test_category": "atomics",
         "executable_path": "test_conformance/atomics/bin/test_atomics",
         "arguments": "atomic_or",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1670,6 +1908,7 @@
         "test_category": "atomics",
         "executable_path": "test_conformance/atomics/bin/test_atomics",
         "arguments": "atomic_xor",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1677,6 +1916,7 @@
         "test_category": "atomics",
         "executable_path": "test_conformance/atomics/bin/test_atomics",
         "arguments": "atomic_add_index",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1684,6 +1924,7 @@
         "test_category": "atomics",
         "executable_path": "test_conformance/atomics/bin/test_atomics",
         "arguments": "atomic_add_index_bin",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1691,6 +1932,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_read_async_int",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1698,6 +1940,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_read_async_uint",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1705,6 +1948,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_read_async_long",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1712,6 +1956,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_read_async_ulong",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1719,6 +1964,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_read_async_short",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1726,6 +1972,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_read_async_ushort",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1733,6 +1980,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_read_async_char",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1740,6 +1988,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_read_async_uchar",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1747,6 +1996,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_read_async_float",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1754,6 +2004,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_read_array_barrier_int",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1761,6 +2012,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_read_array_barrier_uint",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1768,6 +2020,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_read_array_barrier_long",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1775,6 +2028,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_read_array_barrier_ulong",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1782,6 +2036,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_read_array_barrier_short",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1789,6 +2044,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_read_array_barrier_ushort",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1796,6 +2052,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_read_array_barrier_char",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1803,6 +2060,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_read_array_barrier_uchar",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1810,6 +2068,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_read_array_barrier_float",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1817,6 +2076,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_read_int",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1824,6 +2084,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_read_uint",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1831,6 +2092,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_read_long",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1838,6 +2100,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_read_ulong",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1845,6 +2108,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_read_short",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1852,6 +2116,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_read_ushort",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1859,6 +2124,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_read_float",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1866,6 +2132,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_read_half",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1873,6 +2140,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_read_char",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1880,6 +2148,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_read_uchar",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1887,6 +2156,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_read_struct",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1894,6 +2164,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_read_random_size",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1901,6 +2172,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_map_read_int",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1908,6 +2180,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_map_read_uint",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1915,6 +2188,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_map_read_long",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1922,6 +2196,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_map_read_ulong",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1929,6 +2204,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_map_read_short",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1936,6 +2212,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_map_read_ushort",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1943,6 +2220,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_map_read_char",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1950,6 +2228,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_map_read_uchar",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1957,6 +2236,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_map_read_float",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1964,6 +2244,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_map_read_struct",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1971,6 +2252,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_map_write_int",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1978,6 +2260,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_map_write_uint",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1985,6 +2268,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_map_write_long",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1992,6 +2276,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_map_write_ulong",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -1999,6 +2284,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_map_write_short",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2006,6 +2292,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_map_write_ushort",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2013,6 +2300,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_map_write_char",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2020,6 +2308,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_map_write_uchar",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2027,6 +2316,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_map_write_float",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2034,6 +2324,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_map_write_struct",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2041,6 +2332,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_write_int",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2048,6 +2340,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_write_uint",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2055,6 +2348,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_write_short",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2062,6 +2356,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_write_ushort",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2069,6 +2364,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_write_char",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2076,6 +2372,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_write_uchar",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2083,6 +2380,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_write_float",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2090,6 +2388,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_write_half",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2097,6 +2396,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_write_long",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2104,6 +2404,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_write_ulong",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2111,6 +2412,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_write_struct",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2118,6 +2420,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_write_async_int",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2125,6 +2428,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_write_async_uint",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2132,6 +2436,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_write_async_short",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2139,6 +2444,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_write_async_ushort",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2146,6 +2452,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_write_async_char",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2153,6 +2460,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_write_async_uchar",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2160,6 +2468,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_write_async_float",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2167,6 +2476,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_write_async_long",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2174,6 +2484,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_write_async_ulong",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2181,6 +2492,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_copy",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2188,6 +2500,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_partial_copy",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2195,6 +2508,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "mem_read_write_flags",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2202,6 +2516,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "mem_write_only_flags",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2209,6 +2524,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "mem_read_only_flags",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2216,6 +2532,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "mem_copy_host_flags",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2223,6 +2540,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "mem_alloc_ref_flags",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2230,6 +2548,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "array_info_size",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2237,6 +2556,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "sub_buffers_read_write",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2244,6 +2564,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "sub_buffers_read_write_dual_devices",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2251,6 +2572,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "sub_buffers_overlapping",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2258,6 +2580,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_fill_int",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2265,6 +2588,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_fill_uint",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2272,6 +2596,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_fill_short",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2279,6 +2604,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_fill_ushort",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2286,6 +2612,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_fill_char",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2293,6 +2620,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_fill_uchar",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2300,6 +2628,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_fill_long",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2307,6 +2636,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_fill_ulong",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2314,6 +2644,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_fill_float",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2321,6 +2652,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_fill_struct",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2328,6 +2660,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "buffer_migrate",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2335,6 +2668,7 @@
         "test_category": "buffers",
         "executable_path": "test_conformance/buffers/bin/test_buffers",
         "arguments": "image_migrate",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2342,6 +2676,7 @@
         "test_category": "commonfns",
         "executable_path": "test_conformance/commonfns/bin/test_commonfns",
         "arguments": "clamp",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2349,6 +2684,7 @@
         "test_category": "commonfns",
         "executable_path": "test_conformance/commonfns/bin/test_commonfns",
         "arguments": "degrees",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2356,6 +2692,7 @@
         "test_category": "commonfns",
         "executable_path": "test_conformance/commonfns/bin/test_commonfns",
         "arguments": "fmax",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2363,6 +2700,7 @@
         "test_category": "commonfns",
         "executable_path": "test_conformance/commonfns/bin/test_commonfns",
         "arguments": "fmaxf",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2370,6 +2708,7 @@
         "test_category": "commonfns",
         "executable_path": "test_conformance/commonfns/bin/test_commonfns",
         "arguments": "fmin",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2377,6 +2716,7 @@
         "test_category": "commonfns",
         "executable_path": "test_conformance/commonfns/bin/test_commonfns",
         "arguments": "fminf",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2384,6 +2724,7 @@
         "test_category": "commonfns",
         "executable_path": "test_conformance/commonfns/bin/test_commonfns",
         "arguments": "max",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2391,6 +2732,7 @@
         "test_category": "commonfns",
         "executable_path": "test_conformance/commonfns/bin/test_commonfns",
         "arguments": "maxf",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2398,6 +2740,7 @@
         "test_category": "commonfns",
         "executable_path": "test_conformance/commonfns/bin/test_commonfns",
         "arguments": "min",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2405,6 +2748,7 @@
         "test_category": "commonfns",
         "executable_path": "test_conformance/commonfns/bin/test_commonfns",
         "arguments": "minf",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2412,6 +2756,7 @@
         "test_category": "commonfns",
         "executable_path": "test_conformance/commonfns/bin/test_commonfns",
         "arguments": "mix",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2419,6 +2764,7 @@
         "test_category": "commonfns",
         "executable_path": "test_conformance/commonfns/bin/test_commonfns",
         "arguments": "radians",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2426,6 +2772,7 @@
         "test_category": "commonfns",
         "executable_path": "test_conformance/commonfns/bin/test_commonfns",
         "arguments": "step",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2433,6 +2780,7 @@
         "test_category": "commonfns",
         "executable_path": "test_conformance/commonfns/bin/test_commonfns",
         "arguments": "stepf",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2440,6 +2788,7 @@
         "test_category": "commonfns",
         "executable_path": "test_conformance/commonfns/bin/test_commonfns",
         "arguments": "smoothstep",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2447,6 +2796,7 @@
         "test_category": "commonfns",
         "executable_path": "test_conformance/commonfns/bin/test_commonfns",
         "arguments": "smoothstepf",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2454,6 +2804,7 @@
         "test_category": "commonfns",
         "executable_path": "test_conformance/commonfns/bin/test_commonfns",
         "arguments": "sign",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2461,6 +2812,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "load_program_source",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2468,6 +2820,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "load_multistring_source",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2475,6 +2828,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "load_two_kernel_source",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2482,6 +2836,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "load_null_terminated_source",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2489,6 +2844,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "load_null_terminated_multi_line_source",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2496,6 +2852,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "load_null_terminated_partial_multi_line_source",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2503,6 +2860,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "load_discreet_length_source",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2510,6 +2868,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "get_program_source",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2517,6 +2876,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "get_program_build_info",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2524,6 +2884,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "get_program_info",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2531,6 +2892,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "large_compile",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2538,6 +2900,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "async_build",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2545,6 +2908,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "options_build_optimizations",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2552,6 +2916,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "options_build_macro",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2559,6 +2924,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "options_build_macro_existence",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2566,6 +2932,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "options_include_directory",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2573,6 +2940,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "options_denorm_cache",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2580,6 +2948,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "preprocessor_define_udef",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2587,6 +2956,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "preprocessor_include",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2594,6 +2964,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "preprocessor_line_error",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2601,6 +2972,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "preprocessor_pragma",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2608,6 +2980,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "opencl_c_versions",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2615,6 +2988,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "compiler_defines_for_extensions",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2622,6 +2996,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "image_macro",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2629,6 +3004,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "simple_compile_only",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2636,6 +3012,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "simple_static_compile_only",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2643,6 +3020,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "simple_extern_compile_only",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2650,6 +3028,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "simple_compile_with_callback",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2657,6 +3036,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "simple_embedded_header_compile",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2664,6 +3044,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "simple_link_only",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2671,6 +3052,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "two_file_regular_variable_access",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2678,6 +3060,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "two_file_regular_struct_access",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2685,6 +3068,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "two_file_regular_function_access",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2692,6 +3076,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "simple_link_with_callback",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2699,6 +3084,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "simple_embedded_header_link",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2706,6 +3092,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "execute_after_simple_compile_and_link",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2713,6 +3100,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "execute_after_simple_compile_and_link_no_device_info",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2720,6 +3108,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "execute_after_simple_compile_and_link_with_defines",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2727,6 +3116,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "execute_after_simple_compile_and_link_with_callbacks",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2734,6 +3124,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "execute_after_simple_library_with_link",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2741,6 +3132,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "execute_after_two_file_link",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2748,6 +3140,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "execute_after_embedded_header_link",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2755,6 +3148,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "execute_after_included_header_link",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2762,6 +3156,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "execute_after_serialize_reload_object",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2769,6 +3164,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "execute_after_serialize_reload_library",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2776,6 +3172,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "simple_library_only",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2783,6 +3180,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "simple_library_with_callback",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2790,6 +3188,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "simple_library_with_link",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2797,6 +3196,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "two_file_link",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2804,6 +3204,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "multi_file_libraries",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2811,6 +3212,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "multiple_files",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2818,6 +3220,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "multiple_libraries",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2825,6 +3228,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "multiple_files_multiple_libraries",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2832,6 +3236,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "multiple_embedded_headers",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2839,6 +3244,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "program_binary_type",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2846,6 +3252,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "compile_and_link_status_options_log",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2853,6 +3260,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "pragma_unroll",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2860,6 +3268,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "features_macro",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2867,6 +3276,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "unload_valid",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2874,6 +3284,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "unload_repeated",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2881,6 +3292,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "unload_compile_unload_link",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2888,6 +3300,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "unload_build_unload_create_kernel",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2895,6 +3308,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "unload_link_different",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2902,6 +3316,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "unload_build_threaded",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2909,6 +3324,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "unload_build_info",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2916,6 +3332,7 @@
         "test_category": "compiler",
         "executable_path": "test_conformance/compiler/bin/test_compiler",
         "arguments": "unload_program_binaries",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2923,6 +3340,7 @@
         "test_category": "computeinfo",
         "executable_path": "test_conformance/computeinfo/bin/test_computeinfo",
         "arguments": "computeinfo",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2930,6 +3348,7 @@
         "test_category": "computeinfo",
         "executable_path": "test_conformance/computeinfo/bin/test_computeinfo",
         "arguments": "extended_versioning",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2937,6 +3356,7 @@
         "test_category": "computeinfo",
         "executable_path": "test_conformance/computeinfo/bin/test_computeinfo",
         "arguments": "device_uuid",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2944,6 +3364,7 @@
         "test_category": "computeinfo",
         "executable_path": "test_conformance/computeinfo/bin/test_computeinfo",
         "arguments": "conformance_version",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2951,6 +3372,7 @@
         "test_category": "contractions",
         "executable_path": "test_conformance/contractions/bin/test_contractions",
         "arguments": "contractions_float_0",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2958,6 +3380,7 @@
         "test_category": "contractions",
         "executable_path": "test_conformance/contractions/bin/test_contractions",
         "arguments": "contractions_float_1",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2965,6 +3388,7 @@
         "test_category": "contractions",
         "executable_path": "test_conformance/contractions/bin/test_contractions",
         "arguments": "contractions_float_2",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2972,6 +3396,7 @@
         "test_category": "contractions",
         "executable_path": "test_conformance/contractions/bin/test_contractions",
         "arguments": "contractions_float_3",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2979,6 +3404,7 @@
         "test_category": "contractions",
         "executable_path": "test_conformance/contractions/bin/test_contractions",
         "arguments": "contractions_float_4",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2986,6 +3412,7 @@
         "test_category": "contractions",
         "executable_path": "test_conformance/contractions/bin/test_contractions",
         "arguments": "contractions_float_5",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -2993,6 +3420,7 @@
         "test_category": "contractions",
         "executable_path": "test_conformance/contractions/bin/test_contractions",
         "arguments": "contractions_float_6",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3000,6 +3428,7 @@
         "test_category": "contractions",
         "executable_path": "test_conformance/contractions/bin/test_contractions",
         "arguments": "contractions_float_7",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3007,6 +3436,7 @@
         "test_category": "contractions",
         "executable_path": "test_conformance/contractions/bin/test_contractions",
         "arguments": "contractions_double_0",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3014,6 +3444,7 @@
         "test_category": "contractions",
         "executable_path": "test_conformance/contractions/bin/test_contractions",
         "arguments": "contractions_double_1",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3021,6 +3452,7 @@
         "test_category": "contractions",
         "executable_path": "test_conformance/contractions/bin/test_contractions",
         "arguments": "contractions_double_2",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3028,6 +3460,7 @@
         "test_category": "contractions",
         "executable_path": "test_conformance/contractions/bin/test_contractions",
         "arguments": "contractions_double_3",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3035,6 +3468,7 @@
         "test_category": "contractions",
         "executable_path": "test_conformance/contractions/bin/test_contractions",
         "arguments": "contractions_double_4",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3042,6 +3476,7 @@
         "test_category": "contractions",
         "executable_path": "test_conformance/contractions/bin/test_contractions",
         "arguments": "contractions_double_5",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3049,6 +3484,7 @@
         "test_category": "contractions",
         "executable_path": "test_conformance/contractions/bin/test_contractions",
         "arguments": "contractions_double_6",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3056,6 +3492,7 @@
         "test_category": "contractions",
         "executable_path": "test_conformance/contractions/bin/test_contractions",
         "arguments": "contractions_double_7",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3063,6 +3500,7 @@
         "test_category": "device_partition",
         "executable_path": "test_conformance/device_partition/bin/test_device_partition",
         "arguments": "partition_equally",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3070,6 +3508,7 @@
         "test_category": "device_partition",
         "executable_path": "test_conformance/device_partition/bin/test_device_partition",
         "arguments": "partition_by_counts",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3077,6 +3516,7 @@
         "test_category": "device_partition",
         "executable_path": "test_conformance/device_partition/bin/test_device_partition",
         "arguments": "partition_by_affinity_domain_numa",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3084,6 +3524,7 @@
         "test_category": "device_partition",
         "executable_path": "test_conformance/device_partition/bin/test_device_partition",
         "arguments": "partition_by_affinity_domain_l4_cache",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3091,6 +3532,7 @@
         "test_category": "device_partition",
         "executable_path": "test_conformance/device_partition/bin/test_device_partition",
         "arguments": "partition_by_affinity_domain_l3_cache",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3098,6 +3540,7 @@
         "test_category": "device_partition",
         "executable_path": "test_conformance/device_partition/bin/test_device_partition",
         "arguments": "partition_by_affinity_domain_l2_cache",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3105,6 +3548,7 @@
         "test_category": "device_partition",
         "executable_path": "test_conformance/device_partition/bin/test_device_partition",
         "arguments": "partition_by_affinity_domain_l1_cache",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3112,6 +3556,7 @@
         "test_category": "device_partition",
         "executable_path": "test_conformance/device_partition/bin/test_device_partition",
         "arguments": "partition_by_affinity_domain_next_partitionable",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3119,6 +3564,7 @@
         "test_category": "device_partition",
         "executable_path": "test_conformance/device_partition/bin/test_device_partition",
         "arguments": "partition_all",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3126,6 +3572,7 @@
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
         "arguments": "event_get_execute_status",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3133,6 +3580,7 @@
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
         "arguments": "event_get_write_array_status",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3140,6 +3588,7 @@
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
         "arguments": "event_get_read_array_status",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3147,6 +3596,7 @@
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
         "arguments": "event_get_info",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3154,6 +3604,7 @@
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
         "arguments": "event_wait_for_execute",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3161,6 +3612,7 @@
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
         "arguments": "event_wait_for_array",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3168,6 +3620,7 @@
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
         "arguments": "event_flush",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3175,6 +3628,7 @@
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
         "arguments": "event_finish_execute",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3182,6 +3636,7 @@
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
         "arguments": "event_finish_array",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3189,6 +3644,7 @@
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
         "arguments": "event_release_before_done",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3196,6 +3652,7 @@
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
         "arguments": "event_enqueue_marker",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3203,6 +3660,7 @@
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
         "arguments": "event_enqueue_marker_with_event_list",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3210,6 +3668,7 @@
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
         "arguments": "event_enqueue_barrier_with_event_list",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3217,6 +3676,7 @@
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
         "arguments": "out_of_order_event_waitlist_single_queue",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3224,6 +3684,7 @@
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
         "arguments": "out_of_order_event_waitlist_multi_queue",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3231,6 +3692,7 @@
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
         "arguments": "out_of_order_event_waitlist_multi_queue_multi_device",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3238,6 +3700,7 @@
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
         "arguments": "out_of_order_event_enqueue_wait_for_events_single_queue",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3245,6 +3708,7 @@
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
         "arguments": "out_of_order_event_enqueue_wait_for_events_multi_queue",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3252,6 +3716,7 @@
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
         "arguments": "out_of_order_event_enqueue_wait_for_events_multi_queue_multi_device",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3259,6 +3724,7 @@
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
         "arguments": "out_of_order_event_enqueue_marker_single_queue",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3266,6 +3732,7 @@
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
         "arguments": "out_of_order_event_enqueue_marker_multi_queue",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3273,6 +3740,7 @@
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
         "arguments": "out_of_order_event_enqueue_marker_multi_queue_multi_device",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3280,6 +3748,7 @@
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
         "arguments": "out_of_order_event_enqueue_barrier_single_queue",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3287,6 +3756,7 @@
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
         "arguments": "waitlists",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3294,6 +3764,7 @@
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
         "arguments": "userevents",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3301,6 +3772,7 @@
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
         "arguments": "callbacks",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3308,6 +3780,7 @@
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
         "arguments": "callbacks_simultaneous",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3315,6 +3788,7 @@
         "test_category": "events",
         "executable_path": "test_conformance/events/bin/test_events",
         "arguments": "userevents_multithreaded",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3322,6 +3796,7 @@
         "test_category": "geometrics",
         "executable_path": "test_conformance/geometrics/bin/test_geometrics",
         "arguments": "geom_cross",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3329,6 +3804,7 @@
         "test_category": "geometrics",
         "executable_path": "test_conformance/geometrics/bin/test_geometrics",
         "arguments": "geom_dot",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3336,6 +3812,7 @@
         "test_category": "geometrics",
         "executable_path": "test_conformance/geometrics/bin/test_geometrics",
         "arguments": "geom_distance",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3343,6 +3820,7 @@
         "test_category": "geometrics",
         "executable_path": "test_conformance/geometrics/bin/test_geometrics",
         "arguments": "geom_fast_distance",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3350,6 +3828,7 @@
         "test_category": "geometrics",
         "executable_path": "test_conformance/geometrics/bin/test_geometrics",
         "arguments": "geom_length",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3357,6 +3836,7 @@
         "test_category": "geometrics",
         "executable_path": "test_conformance/geometrics/bin/test_geometrics",
         "arguments": "geom_fast_length",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3364,6 +3844,7 @@
         "test_category": "geometrics",
         "executable_path": "test_conformance/geometrics/bin/test_geometrics",
         "arguments": "geom_normalize",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3371,6 +3852,7 @@
         "test_category": "geometrics",
         "executable_path": "test_conformance/geometrics/bin/test_geometrics",
         "arguments": "geom_fast_normalize",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3378,6 +3860,7 @@
         "test_category": "half",
         "executable_path": "test_conformance/half/bin/test_half",
         "arguments": "vload_half",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3385,6 +3868,7 @@
         "test_category": "half",
         "executable_path": "test_conformance/half/bin/test_half",
         "arguments": "vloada_half",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3392,6 +3876,7 @@
         "test_category": "half",
         "executable_path": "test_conformance/half/bin/test_half",
         "arguments": "vstore_half",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3399,6 +3884,7 @@
         "test_category": "half",
         "executable_path": "test_conformance/half/bin/test_half",
         "arguments": "vstorea_half",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3406,6 +3892,7 @@
         "test_category": "half",
         "executable_path": "test_conformance/half/bin/test_half",
         "arguments": "vstore_half_rte",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3413,6 +3900,7 @@
         "test_category": "half",
         "executable_path": "test_conformance/half/bin/test_half",
         "arguments": "vstorea_half_rte",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3420,6 +3908,7 @@
         "test_category": "half",
         "executable_path": "test_conformance/half/bin/test_half",
         "arguments": "vstore_half_rtz",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3427,6 +3916,7 @@
         "test_category": "half",
         "executable_path": "test_conformance/half/bin/test_half",
         "arguments": "vstorea_half_rtz",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3434,6 +3924,7 @@
         "test_category": "half",
         "executable_path": "test_conformance/half/bin/test_half",
         "arguments": "vstore_half_rtp",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3441,6 +3932,7 @@
         "test_category": "half",
         "executable_path": "test_conformance/half/bin/test_half",
         "arguments": "vstorea_half_rtp",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3448,6 +3940,7 @@
         "test_category": "half",
         "executable_path": "test_conformance/half/bin/test_half",
         "arguments": "vstore_half_rtn",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3455,6 +3948,7 @@
         "test_category": "half",
         "executable_path": "test_conformance/half/bin/test_half",
         "arguments": "vstorea_half_rtn",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3462,6 +3956,7 @@
         "test_category": "half",
         "executable_path": "test_conformance/half/bin/test_half",
         "arguments": "roundTrip",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3469,6 +3964,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "integer_clz",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3476,6 +3972,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "integer_ctz",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3483,6 +3980,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "integer_hadd",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3490,6 +3988,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "integer_rhadd",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3497,6 +3996,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "integer_mul_hi",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3504,6 +4004,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "integer_rotate",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3511,6 +4012,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "integer_clamp",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3518,6 +4020,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "integer_mad_sat",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3525,6 +4028,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "integer_mad_hi",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3532,6 +4036,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "integer_min",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3539,6 +4044,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "integer_max",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3546,6 +4052,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "integer_upsample",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3553,6 +4060,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "integer_abs",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3560,6 +4068,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "integer_abs_diff",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3567,6 +4076,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "integer_add_sat",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3574,6 +4084,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "integer_sub_sat",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3581,6 +4092,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "integer_addAssign",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3588,6 +4100,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "integer_subtractAssign",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3595,6 +4108,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "integer_multiplyAssign",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3602,6 +4116,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "integer_divideAssign",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3609,6 +4124,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "integer_moduloAssign",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3616,6 +4132,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "integer_andAssign",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3623,6 +4140,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "integer_orAssign",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3630,6 +4148,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "integer_exclusiveOrAssign",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3637,6 +4156,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "unary_ops_increment",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3644,6 +4164,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "unary_ops_decrement",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3651,6 +4172,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "unary_ops_full",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3658,6 +4180,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "integer_mul24",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3665,6 +4188,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "integer_mad24",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3672,230 +4196,263 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "long_math",
-        "time_limit": 120
+        "environment": "CL_TEST_SINGLE_THREADED",
+        "time_limit": 480
     },
     {
         "test_name": "long_logic",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "long_logic",
-        "time_limit": 120
+        "environment": "CL_TEST_SINGLE_THREADED",
+        "time_limit": 480
     },
     {
         "test_name": "long_shift",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "long_shift",
-        "time_limit": 120
+        "environment": "CL_TEST_SINGLE_THREADED",
+        "time_limit": 480
     },
     {
         "test_name": "long_compare",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "long_compare",
-        "time_limit": 120
+        "environment": "CL_TEST_SINGLE_THREADED",
+        "time_limit": 480
     },
     {
         "test_name": "ulong_math",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "ulong_math",
-        "time_limit": 120
+        "environment": "CL_TEST_SINGLE_THREADED",
+        "time_limit": 480
     },
     {
         "test_name": "ulong_logic",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "ulong_logic",
-        "time_limit": 120
+        "environment": "CL_TEST_SINGLE_THREADED",
+        "time_limit": 480
     },
     {
         "test_name": "ulong_shift",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "ulong_shift",
-        "time_limit": 120
+        "environment": "CL_TEST_SINGLE_THREADED",
+        "time_limit": 480
     },
     {
         "test_name": "ulong_compare",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "ulong_compare",
-        "time_limit": 120
+        "environment": "CL_TEST_SINGLE_THREADED",
+        "time_limit": 480
     },
     {
         "test_name": "int_math",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "int_math",
-        "time_limit": 120
+        "environment": "CL_TEST_SINGLE_THREADED",
+        "time_limit": 480
     },
     {
         "test_name": "int_logic",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "int_logic",
-        "time_limit": 120
+        "environment": "CL_TEST_SINGLE_THREADED",
+        "time_limit": 480
     },
     {
         "test_name": "int_shift",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "int_shift",
-        "time_limit": 120
+        "environment": "CL_TEST_SINGLE_THREADED",
+        "time_limit": 480
     },
     {
         "test_name": "int_compare",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "int_compare",
-        "time_limit": 120
+        "environment": "CL_TEST_SINGLE_THREADED",
+        "time_limit": 480
     },
     {
         "test_name": "uint_math",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "uint_math",
-        "time_limit": 120
+        "environment": "CL_TEST_SINGLE_THREADED",
+        "time_limit": 480
     },
     {
         "test_name": "uint_logic",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "uint_logic",
-        "time_limit": 120
+        "environment": "CL_TEST_SINGLE_THREADED",
+        "time_limit": 480
     },
     {
         "test_name": "uint_shift",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "uint_shift",
-        "time_limit": 120
+        "environment": "CL_TEST_SINGLE_THREADED",
+        "time_limit": 480
     },
     {
         "test_name": "uint_compare",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "uint_compare",
-        "time_limit": 120
+        "environment": "CL_TEST_SINGLE_THREADED",
+        "time_limit": 480
     },
     {
         "test_name": "short_math",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "short_math",
-        "time_limit": 120
+        "environment": "CL_TEST_SINGLE_THREADED",
+        "time_limit": 480
     },
     {
         "test_name": "short_logic",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "short_logic",
-        "time_limit": 120
+        "environment": "CL_TEST_SINGLE_THREADED",
+        "time_limit": 480
     },
     {
         "test_name": "short_shift",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "short_shift",
-        "time_limit": 120
+        "environment": "CL_TEST_SINGLE_THREADED",
+        "time_limit": 480
     },
     {
         "test_name": "short_compare",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "short_compare",
-        "time_limit": 120
+        "environment": "CL_TEST_SINGLE_THREADED",
+        "time_limit": 480
     },
     {
         "test_name": "ushort_math",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "ushort_math",
-        "time_limit": 120
+        "environment": "CL_TEST_SINGLE_THREADED",
+        "time_limit": 480
     },
     {
         "test_name": "ushort_logic",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "ushort_logic",
-        "time_limit": 120
+        "environment": "CL_TEST_SINGLE_THREADED",
+        "time_limit": 480
     },
     {
         "test_name": "ushort_shift",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "ushort_shift",
-        "time_limit": 120
+        "environment": "CL_TEST_SINGLE_THREADED",
+        "time_limit": 480
     },
     {
         "test_name": "ushort_compare",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "ushort_compare",
-        "time_limit": 120
+        "environment": "CL_TEST_SINGLE_THREADED",
+        "time_limit": 480
     },
     {
         "test_name": "char_math",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "char_math",
-        "time_limit": 120
+        "environment": "CL_TEST_SINGLE_THREADED",
+        "time_limit": 480
     },
     {
         "test_name": "char_logic",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "char_logic",
-        "time_limit": 120
+        "environment": "CL_TEST_SINGLE_THREADED",
+        "time_limit": 480
     },
     {
         "test_name": "char_shift",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "char_shift",
-        "time_limit": 120
+        "environment": "CL_TEST_SINGLE_THREADED",
+        "time_limit": 480
     },
     {
         "test_name": "char_compare",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "char_compare",
-        "time_limit": 120
+        "environment": "CL_TEST_SINGLE_THREADED",
+        "time_limit": 480
     },
     {
         "test_name": "uchar_math",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "uchar_math",
-        "time_limit": 120
+        "environment": "CL_TEST_SINGLE_THREADED",
+        "time_limit": 480
     },
     {
         "test_name": "uchar_logic",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "uchar_logic",
-        "time_limit": 120
+        "environment": "CL_TEST_SINGLE_THREADED",
+        "time_limit": 480
     },
     {
         "test_name": "uchar_shift",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "uchar_shift",
-        "time_limit": 120
+        "environment": "CL_TEST_SINGLE_THREADED",
+        "time_limit": 480
     },
     {
         "test_name": "uchar_compare",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "uchar_compare",
-        "time_limit": 120
+        "environment": "CL_TEST_SINGLE_THREADED",
+        "time_limit": 480
     },
     {
         "test_name": "popcount",
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "popcount",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3903,6 +4460,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "quick_long_math",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3910,6 +4468,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "quick_long_logic",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3917,6 +4476,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "quick_long_shift",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3924,6 +4484,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "quick_long_compare",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3931,6 +4492,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "quick_ulong_math",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3938,6 +4500,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "quick_ulong_logic",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3945,6 +4508,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "quick_ulong_shift",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3952,6 +4516,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "quick_ulong_compare",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3959,6 +4524,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "quick_int_math",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3966,6 +4532,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "quick_int_logic",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3973,6 +4540,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "quick_int_shift",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3980,6 +4548,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "quick_int_compare",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3987,6 +4556,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "quick_uint_math",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -3994,6 +4564,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "quick_uint_logic",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4001,6 +4572,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "quick_uint_shift",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4008,6 +4580,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "quick_uint_compare",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4015,6 +4588,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "quick_short_math",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4022,6 +4596,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "quick_short_logic",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4029,6 +4604,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "quick_short_shift",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4036,6 +4612,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "quick_short_compare",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4043,6 +4620,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "quick_ushort_math",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4050,6 +4628,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "quick_ushort_logic",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4057,6 +4636,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "quick_ushort_shift",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4064,6 +4644,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "quick_ushort_compare",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4071,6 +4652,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "quick_char_math",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4078,6 +4660,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "quick_char_logic",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4085,6 +4668,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "quick_char_shift",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4092,6 +4676,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "quick_char_compare",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4099,6 +4684,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "quick_uchar_math",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4106,6 +4692,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "quick_uchar_logic",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4113,6 +4700,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "quick_uchar_shift",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4120,6 +4708,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "quick_uchar_compare",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4127,6 +4716,7 @@
         "test_category": "integer_ops",
         "executable_path": "test_conformance/integer_ops/bin/test_integer_ops",
         "arguments": "vector_scalar",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4134,6 +4724,7 @@
         "test_category": "mem_host_flags",
         "executable_path": "test_conformance/mem_host_flags/bin/test_mem_host_flags",
         "arguments": "mem_host_read_only_buffer",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4141,6 +4732,7 @@
         "test_category": "mem_host_flags",
         "executable_path": "test_conformance/mem_host_flags/bin/test_mem_host_flags",
         "arguments": "mem_host_read_only_subbuffer",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4148,6 +4740,7 @@
         "test_category": "mem_host_flags",
         "executable_path": "test_conformance/mem_host_flags/bin/test_mem_host_flags",
         "arguments": "mem_host_write_only_buffer",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4155,6 +4748,7 @@
         "test_category": "mem_host_flags",
         "executable_path": "test_conformance/mem_host_flags/bin/test_mem_host_flags",
         "arguments": "mem_host_write_only_subbuffer",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4162,6 +4756,7 @@
         "test_category": "mem_host_flags",
         "executable_path": "test_conformance/mem_host_flags/bin/test_mem_host_flags",
         "arguments": "mem_host_no_access_buffer",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4169,6 +4764,7 @@
         "test_category": "mem_host_flags",
         "executable_path": "test_conformance/mem_host_flags/bin/test_mem_host_flags",
         "arguments": "mem_host_no_access_subbuffer",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4176,6 +4772,7 @@
         "test_category": "mem_host_flags",
         "executable_path": "test_conformance/mem_host_flags/bin/test_mem_host_flags",
         "arguments": "mem_host_read_only_image",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4183,6 +4780,7 @@
         "test_category": "mem_host_flags",
         "executable_path": "test_conformance/mem_host_flags/bin/test_mem_host_flags",
         "arguments": "mem_host_write_only_image",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4190,6 +4788,7 @@
         "test_category": "mem_host_flags",
         "executable_path": "test_conformance/mem_host_flags/bin/test_mem_host_flags",
         "arguments": "mem_host_no_access_image",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4197,6 +4796,7 @@
         "test_category": "multiple_device_context",
         "executable_path": "test_conformance/multiple_device_context/bin/test_multiples",
         "arguments": "context_multiple_contexts_same_device",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4204,6 +4804,7 @@
         "test_category": "multiple_device_context",
         "executable_path": "test_conformance/multiple_device_context/bin/test_multiples",
         "arguments": "context_two_contexts_same_device",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4211,6 +4812,7 @@
         "test_category": "multiple_device_context",
         "executable_path": "test_conformance/multiple_device_context/bin/test_multiples",
         "arguments": "context_three_contexts_same_device",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4218,6 +4820,7 @@
         "test_category": "multiple_device_context",
         "executable_path": "test_conformance/multiple_device_context/bin/test_multiples",
         "arguments": "context_four_contexts_same_device",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4225,6 +4828,7 @@
         "test_category": "multiple_device_context",
         "executable_path": "test_conformance/multiple_device_context/bin/test_multiples",
         "arguments": "two_devices",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4232,6 +4836,7 @@
         "test_category": "multiple_device_context",
         "executable_path": "test_conformance/multiple_device_context/bin/test_multiples",
         "arguments": "max_devices",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4239,6 +4844,7 @@
         "test_category": "multiple_device_context",
         "executable_path": "test_conformance/multiple_device_context/bin/test_multiples",
         "arguments": "hundred_queues",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4246,6 +4852,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "int_0",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4253,6 +4860,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "int_1",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4260,6 +4868,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "int_2",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4267,6 +4876,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "int_3",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4274,6 +4884,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "int_4",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4281,6 +4892,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "int_5",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4288,6 +4900,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "int_6",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4295,6 +4908,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "int_7",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4302,6 +4916,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "int_8",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4309,6 +4924,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "float_0",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4316,6 +4932,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "float_1",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4323,6 +4940,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "float_2",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4330,6 +4948,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "float_3",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4337,6 +4956,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "float_4",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4344,6 +4964,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "float_5",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4351,6 +4972,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "float_6",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4358,6 +4980,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "float_7",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4365,6 +4988,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "float_8",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4372,6 +4996,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "float_9",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4379,6 +5004,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "float_10",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4386,6 +5012,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "float_11",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4393,6 +5020,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "float_12",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4400,6 +5028,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "float_13",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4407,6 +5036,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "float_14",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4414,6 +5044,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "float_15",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4421,6 +5052,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "float_16",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4428,6 +5060,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "float_17",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4435,6 +5068,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "float_limits_0",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4442,6 +5076,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "float_limits_1",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4449,6 +5084,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "float_limits_2",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4456,6 +5092,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "octal_0",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4463,6 +5100,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "octal_1",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4470,6 +5108,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "octal_2",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4477,6 +5116,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "octal_3",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4484,6 +5124,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "unsigned_0",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4491,6 +5132,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "unsigned_1",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4498,6 +5140,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "hexadecimal_0",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4505,6 +5148,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "hexadecimal_1",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4512,6 +5156,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "hexadecimal_2",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4519,6 +5164,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "hexadecimal_3",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4526,6 +5172,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "hexadecimal_4",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4533,6 +5180,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "char_0",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4540,6 +5188,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "char_1",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4547,6 +5196,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "char_2",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4554,6 +5204,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "string_0",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4561,6 +5212,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "string_1",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4568,6 +5220,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "string_2",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4575,6 +5228,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "vector_0",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4582,6 +5236,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "vector_1",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4589,6 +5244,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "vector_2",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4596,6 +5252,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "vector_3",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4603,6 +5260,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "vector_4",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4610,6 +5268,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "address_space_0",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4617,6 +5276,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "address_space_1",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4624,6 +5284,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "address_space_2",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4631,6 +5292,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "address_space_3",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4638,6 +5300,7 @@
         "test_category": "printf",
         "executable_path": "test_conformance/printf/bin/test_printf",
         "arguments": "address_space_4",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4645,6 +5308,7 @@
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
         "arguments": "read_array_int",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4652,6 +5316,7 @@
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
         "arguments": "read_array_uint",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4659,6 +5324,7 @@
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
         "arguments": "read_array_long",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4666,6 +5332,7 @@
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
         "arguments": "read_array_ulong",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4673,6 +5340,7 @@
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
         "arguments": "read_array_short",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4680,6 +5348,7 @@
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
         "arguments": "read_array_ushort",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4687,6 +5356,7 @@
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
         "arguments": "read_array_float",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4694,6 +5364,7 @@
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
         "arguments": "read_array_char",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4701,6 +5372,7 @@
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
         "arguments": "read_array_uchar",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4708,6 +5380,7 @@
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
         "arguments": "read_array_struct",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4715,6 +5388,7 @@
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
         "arguments": "write_array_int",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4722,6 +5396,7 @@
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
         "arguments": "write_array_uint",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4729,6 +5404,7 @@
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
         "arguments": "write_array_long",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4736,6 +5412,7 @@
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
         "arguments": "write_array_ulong",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4743,6 +5420,7 @@
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
         "arguments": "write_array_short",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4750,6 +5428,7 @@
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
         "arguments": "write_array_ushort",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4757,6 +5436,7 @@
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
         "arguments": "write_array_float",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4764,6 +5444,7 @@
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
         "arguments": "write_array_char",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4771,6 +5452,7 @@
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
         "arguments": "write_array_uchar",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4778,6 +5460,7 @@
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
         "arguments": "write_array_struct",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4785,6 +5468,7 @@
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
         "arguments": "read_image_float",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4792,6 +5476,7 @@
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
         "arguments": "read_image_char",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4799,6 +5484,7 @@
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
         "arguments": "read_image_uchar",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4806,6 +5492,7 @@
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
         "arguments": "write_image_float",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4813,6 +5500,7 @@
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
         "arguments": "write_image_char",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4820,6 +5508,7 @@
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
         "arguments": "write_image_uchar",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4827,6 +5516,7 @@
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
         "arguments": "copy_array",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4834,6 +5524,7 @@
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
         "arguments": "copy_partial_array",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4841,6 +5532,7 @@
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
         "arguments": "copy_image",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4848,6 +5540,7 @@
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
         "arguments": "copy_array_to_image",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4855,6 +5548,7 @@
         "test_category": "profiling",
         "executable_path": "test_conformance/profiling/bin/test_profiling",
         "arguments": "execute",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4862,6 +5556,7 @@
         "test_category": "relationals",
         "executable_path": "test_conformance/relationals/bin/test_relationals",
         "arguments": "relational_any",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4869,6 +5564,7 @@
         "test_category": "relationals",
         "executable_path": "test_conformance/relationals/bin/test_relationals",
         "arguments": "relational_all",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4876,6 +5572,7 @@
         "test_category": "relationals",
         "executable_path": "test_conformance/relationals/bin/test_relationals",
         "arguments": "relational_bitselect",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4883,6 +5580,7 @@
         "test_category": "relationals",
         "executable_path": "test_conformance/relationals/bin/test_relationals",
         "arguments": "relational_select_signed",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4890,6 +5588,7 @@
         "test_category": "relationals",
         "executable_path": "test_conformance/relationals/bin/test_relationals",
         "arguments": "relational_select_unsigned",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4897,6 +5596,7 @@
         "test_category": "relationals",
         "executable_path": "test_conformance/relationals/bin/test_relationals",
         "arguments": "relational_isequal",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4904,6 +5604,7 @@
         "test_category": "relationals",
         "executable_path": "test_conformance/relationals/bin/test_relationals",
         "arguments": "relational_isnotequal",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4911,6 +5612,7 @@
         "test_category": "relationals",
         "executable_path": "test_conformance/relationals/bin/test_relationals",
         "arguments": "relational_isgreater",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4918,6 +5620,7 @@
         "test_category": "relationals",
         "executable_path": "test_conformance/relationals/bin/test_relationals",
         "arguments": "relational_isgreaterequal",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4925,6 +5628,7 @@
         "test_category": "relationals",
         "executable_path": "test_conformance/relationals/bin/test_relationals",
         "arguments": "relational_isless",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4932,6 +5636,7 @@
         "test_category": "relationals",
         "executable_path": "test_conformance/relationals/bin/test_relationals",
         "arguments": "relational_islessequal",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4939,6 +5644,7 @@
         "test_category": "relationals",
         "executable_path": "test_conformance/relationals/bin/test_relationals",
         "arguments": "relational_islessgreater",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4946,6 +5652,7 @@
         "test_category": "relationals",
         "executable_path": "test_conformance/relationals/bin/test_relationals",
         "arguments": "shuffle_copy",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4953,6 +5660,7 @@
         "test_category": "relationals",
         "executable_path": "test_conformance/relationals/bin/test_relationals",
         "arguments": "shuffle_function_call",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4960,6 +5668,7 @@
         "test_category": "relationals",
         "executable_path": "test_conformance/relationals/bin/test_relationals",
         "arguments": "shuffle_array_cast",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4967,6 +5676,7 @@
         "test_category": "relationals",
         "executable_path": "test_conformance/relationals/bin/test_relationals",
         "arguments": "shuffle_built_in",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4974,6 +5684,7 @@
         "test_category": "relationals",
         "executable_path": "test_conformance/relationals/bin/test_relationals",
         "arguments": "shuffle_built_in_dual_input",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4981,6 +5692,7 @@
         "test_category": "select",
         "executable_path": "test_conformance/select/bin/test_select",
         "arguments": "select_uchar_uchar",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4988,6 +5700,7 @@
         "test_category": "select",
         "executable_path": "test_conformance/select/bin/test_select",
         "arguments": "select_uchar_char",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -4995,6 +5708,7 @@
         "test_category": "select",
         "executable_path": "test_conformance/select/bin/test_select",
         "arguments": "select_char_uchar",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5002,6 +5716,7 @@
         "test_category": "select",
         "executable_path": "test_conformance/select/bin/test_select",
         "arguments": "select_char_char",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5009,6 +5724,7 @@
         "test_category": "select",
         "executable_path": "test_conformance/select/bin/test_select",
         "arguments": "select_ushort_ushort",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5016,6 +5732,7 @@
         "test_category": "select",
         "executable_path": "test_conformance/select/bin/test_select",
         "arguments": "select_ushort_short",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5023,6 +5740,7 @@
         "test_category": "select",
         "executable_path": "test_conformance/select/bin/test_select",
         "arguments": "select_short_ushort",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5030,6 +5748,7 @@
         "test_category": "select",
         "executable_path": "test_conformance/select/bin/test_select",
         "arguments": "select_short_short",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5037,6 +5756,7 @@
         "test_category": "select",
         "executable_path": "test_conformance/select/bin/test_select",
         "arguments": "select_uint_uint",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5044,6 +5764,7 @@
         "test_category": "select",
         "executable_path": "test_conformance/select/bin/test_select",
         "arguments": "select_uint_int",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5051,6 +5772,7 @@
         "test_category": "select",
         "executable_path": "test_conformance/select/bin/test_select",
         "arguments": "select_int_uint",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5058,6 +5780,7 @@
         "test_category": "select",
         "executable_path": "test_conformance/select/bin/test_select",
         "arguments": "select_int_int",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5065,6 +5788,7 @@
         "test_category": "select",
         "executable_path": "test_conformance/select/bin/test_select",
         "arguments": "select_float_uint",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5072,6 +5796,7 @@
         "test_category": "select",
         "executable_path": "test_conformance/select/bin/test_select",
         "arguments": "select_float_int",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5079,6 +5804,7 @@
         "test_category": "select",
         "executable_path": "test_conformance/select/bin/test_select",
         "arguments": "select_ulong_ulong",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5086,6 +5812,7 @@
         "test_category": "select",
         "executable_path": "test_conformance/select/bin/test_select",
         "arguments": "select_ulong_long",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5093,6 +5820,7 @@
         "test_category": "select",
         "executable_path": "test_conformance/select/bin/test_select",
         "arguments": "select_long_ulong",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5100,6 +5828,7 @@
         "test_category": "select",
         "executable_path": "test_conformance/select/bin/test_select",
         "arguments": "select_long_long",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5107,6 +5836,7 @@
         "test_category": "select",
         "executable_path": "test_conformance/select/bin/test_select",
         "arguments": "select_double_ulong",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5114,6 +5844,7 @@
         "test_category": "select",
         "executable_path": "test_conformance/select/bin/test_select",
         "arguments": "select_double_long",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5121,6 +5852,7 @@
         "test_category": "thread_dimensions",
         "executable_path": "test_conformance/thread_dimensions/bin/test_thread_dimensions",
         "arguments": "quick_1d_explicit_local",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5128,6 +5860,7 @@
         "test_category": "thread_dimensions",
         "executable_path": "test_conformance/thread_dimensions/bin/test_thread_dimensions",
         "arguments": "quick_2d_explicit_local",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5135,6 +5868,7 @@
         "test_category": "thread_dimensions",
         "executable_path": "test_conformance/thread_dimensions/bin/test_thread_dimensions",
         "arguments": "quick_3d_explicit_local",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5142,6 +5876,7 @@
         "test_category": "thread_dimensions",
         "executable_path": "test_conformance/thread_dimensions/bin/test_thread_dimensions",
         "arguments": "quick_1d_implicit_local",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5149,6 +5884,7 @@
         "test_category": "thread_dimensions",
         "executable_path": "test_conformance/thread_dimensions/bin/test_thread_dimensions",
         "arguments": "quick_2d_implicit_local",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5156,6 +5892,7 @@
         "test_category": "thread_dimensions",
         "executable_path": "test_conformance/thread_dimensions/bin/test_thread_dimensions",
         "arguments": "quick_3d_implicit_local",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5163,6 +5900,7 @@
         "test_category": "thread_dimensions",
         "executable_path": "test_conformance/thread_dimensions/bin/test_thread_dimensions",
         "arguments": "full_1d_explicit_local",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5170,6 +5908,7 @@
         "test_category": "thread_dimensions",
         "executable_path": "test_conformance/thread_dimensions/bin/test_thread_dimensions",
         "arguments": "full_2d_explicit_local",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5177,6 +5916,7 @@
         "test_category": "thread_dimensions",
         "executable_path": "test_conformance/thread_dimensions/bin/test_thread_dimensions",
         "arguments": "full_3d_explicit_local",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5184,6 +5924,7 @@
         "test_category": "thread_dimensions",
         "executable_path": "test_conformance/thread_dimensions/bin/test_thread_dimensions",
         "arguments": "full_1d_implicit_local",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5191,6 +5932,7 @@
         "test_category": "thread_dimensions",
         "executable_path": "test_conformance/thread_dimensions/bin/test_thread_dimensions",
         "arguments": "full_2d_implicit_local",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5198,6 +5940,7 @@
         "test_category": "thread_dimensions",
         "executable_path": "test_conformance/thread_dimensions/bin/test_thread_dimensions",
         "arguments": "full_3d_implicit_local",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5205,6 +5948,7 @@
         "test_category": "vectors",
         "executable_path": "test_conformance/vectors/bin/test_vectors",
         "arguments": "step_type",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5212,6 +5956,7 @@
         "test_category": "vectors",
         "executable_path": "test_conformance/vectors/bin/test_vectors",
         "arguments": "step_var",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5219,6 +5964,7 @@
         "test_category": "vectors",
         "executable_path": "test_conformance/vectors/bin/test_vectors",
         "arguments": "step_typedef_type",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5226,6 +5972,7 @@
         "test_category": "vectors",
         "executable_path": "test_conformance/vectors/bin/test_vectors",
         "arguments": "step_typedef_var",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5233,6 +5980,7 @@
         "test_category": "vectors",
         "executable_path": "test_conformance/vectors/bin/test_vectors",
         "arguments": "vec_align_array",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5240,6 +5988,7 @@
         "test_category": "vectors",
         "executable_path": "test_conformance/vectors/bin/test_vectors",
         "arguments": "vec_align_struct",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5247,6 +5996,7 @@
         "test_category": "vectors",
         "executable_path": "test_conformance/vectors/bin/test_vectors",
         "arguments": "vec_align_packed_struct",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5254,6 +6004,7 @@
         "test_category": "vectors",
         "executable_path": "test_conformance/vectors/bin/test_vectors",
         "arguments": "vec_align_struct_arr",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5261,6 +6012,7 @@
         "test_category": "vectors",
         "executable_path": "test_conformance/vectors/bin/test_vectors",
         "arguments": "vec_align_packed_struct_arr",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5268,6 +6020,7 @@
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
         "arguments": "atomic_init",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5275,6 +6028,7 @@
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
         "arguments": "atomic_store",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5282,6 +6036,7 @@
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
         "arguments": "atomic_load",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5289,6 +6044,7 @@
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
         "arguments": "atomic_exchange",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5296,6 +6052,7 @@
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
         "arguments": "atomic_compare_exchange_weak",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5303,6 +6060,7 @@
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
         "arguments": "atomic_compare_exchange_strong",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5310,6 +6068,7 @@
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
         "arguments": "atomic_fetch_add",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5317,6 +6076,7 @@
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
         "arguments": "atomic_fetch_sub",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5324,6 +6084,7 @@
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
         "arguments": "atomic_fetch_and",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5331,6 +6092,7 @@
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
         "arguments": "atomic_fetch_or",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5338,6 +6100,7 @@
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
         "arguments": "atomic_fetch_orand",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5345,6 +6108,7 @@
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
         "arguments": "atomic_fetch_xor",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5352,6 +6116,7 @@
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
         "arguments": "atomic_fetch_xor2",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5359,6 +6124,7 @@
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
         "arguments": "atomic_fetch_min",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5366,6 +6132,7 @@
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
         "arguments": "atomic_fetch_max",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5373,6 +6140,7 @@
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
         "arguments": "atomic_flag",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5380,6 +6148,7 @@
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
         "arguments": "atomic_fence",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5387,6 +6156,7 @@
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
         "arguments": "svm_atomic_init",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5394,6 +6164,7 @@
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
         "arguments": "svm_atomic_store",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5401,6 +6172,7 @@
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
         "arguments": "svm_atomic_load",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5408,6 +6180,7 @@
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
         "arguments": "svm_atomic_exchange",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5415,6 +6188,7 @@
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
         "arguments": "svm_atomic_compare_exchange_weak",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5422,6 +6196,7 @@
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
         "arguments": "svm_atomic_compare_exchange_strong",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5429,6 +6204,7 @@
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
         "arguments": "svm_atomic_fetch_add",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5436,6 +6212,7 @@
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
         "arguments": "svm_atomic_fetch_sub",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5443,6 +6220,7 @@
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
         "arguments": "svm_atomic_fetch_and",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5450,6 +6228,7 @@
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
         "arguments": "svm_atomic_fetch_or",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5457,6 +6236,7 @@
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
         "arguments": "svm_atomic_fetch_orand",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5464,6 +6244,7 @@
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
         "arguments": "svm_atomic_fetch_xor",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5471,6 +6252,7 @@
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
         "arguments": "svm_atomic_fetch_xor2",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5478,6 +6260,7 @@
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
         "arguments": "svm_atomic_fetch_min",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5485,6 +6268,7 @@
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
         "arguments": "svm_atomic_fetch_max",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5492,6 +6276,7 @@
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
         "arguments": "svm_atomic_flag",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5499,6 +6284,7 @@
         "test_category": "c11_atomics",
         "executable_path": "test_conformance/c11_atomics/bin/test_c11_atomics",
         "arguments": "svm_atomic_fence",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5506,6 +6292,7 @@
         "test_category": "device_execution",
         "executable_path": "test_conformance/device_execution/bin/test_device_execution",
         "arguments": "device_info",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5513,6 +6300,7 @@
         "test_category": "device_execution",
         "executable_path": "test_conformance/device_execution/bin/test_device_execution",
         "arguments": "device_queue",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5520,6 +6308,7 @@
         "test_category": "device_execution",
         "executable_path": "test_conformance/device_execution/bin/test_device_execution",
         "arguments": "execute_block",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5527,6 +6316,7 @@
         "test_category": "device_execution",
         "executable_path": "test_conformance/device_execution/bin/test_device_execution",
         "arguments": "enqueue_block",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5534,6 +6324,7 @@
         "test_category": "device_execution",
         "executable_path": "test_conformance/device_execution/bin/test_device_execution",
         "arguments": "enqueue_nested_blocks",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5541,6 +6332,7 @@
         "test_category": "device_execution",
         "executable_path": "test_conformance/device_execution/bin/test_device_execution",
         "arguments": "enqueue_wg_size",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5548,6 +6340,7 @@
         "test_category": "device_execution",
         "executable_path": "test_conformance/device_execution/bin/test_device_execution",
         "arguments": "enqueue_flags",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5555,6 +6348,7 @@
         "test_category": "device_execution",
         "executable_path": "test_conformance/device_execution/bin/test_device_execution",
         "arguments": "enqueue_multi_queue",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5562,6 +6356,7 @@
         "test_category": "device_execution",
         "executable_path": "test_conformance/device_execution/bin/test_device_execution",
         "arguments": "host_multi_queue",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5569,6 +6364,7 @@
         "test_category": "device_execution",
         "executable_path": "test_conformance/device_execution/bin/test_device_execution",
         "arguments": "enqueue_ndrange",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5576,6 +6372,7 @@
         "test_category": "device_execution",
         "executable_path": "test_conformance/device_execution/bin/test_device_execution",
         "arguments": "host_queue_order",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5583,6 +6380,7 @@
         "test_category": "device_execution",
         "executable_path": "test_conformance/device_execution/bin/test_device_execution",
         "arguments": "enqueue_profiling",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5590,6 +6388,7 @@
         "test_category": "non_uniform_work_group",
         "executable_path": "test_conformance/non_uniform_work_group/bin/test_non_uniform_work_group",
         "arguments": "non_uniform_1d_basic",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5597,6 +6396,7 @@
         "test_category": "non_uniform_work_group",
         "executable_path": "test_conformance/non_uniform_work_group/bin/test_non_uniform_work_group",
         "arguments": "non_uniform_1d_atomics",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5604,6 +6404,7 @@
         "test_category": "non_uniform_work_group",
         "executable_path": "test_conformance/non_uniform_work_group/bin/test_non_uniform_work_group",
         "arguments": "non_uniform_1d_barriers",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5611,6 +6412,7 @@
         "test_category": "non_uniform_work_group",
         "executable_path": "test_conformance/non_uniform_work_group/bin/test_non_uniform_work_group",
         "arguments": "non_uniform_2d_basic",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5618,6 +6420,7 @@
         "test_category": "non_uniform_work_group",
         "executable_path": "test_conformance/non_uniform_work_group/bin/test_non_uniform_work_group",
         "arguments": "non_uniform_2d_atomics",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5625,6 +6428,7 @@
         "test_category": "non_uniform_work_group",
         "executable_path": "test_conformance/non_uniform_work_group/bin/test_non_uniform_work_group",
         "arguments": "non_uniform_2d_barriers",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5632,6 +6436,7 @@
         "test_category": "non_uniform_work_group",
         "executable_path": "test_conformance/non_uniform_work_group/bin/test_non_uniform_work_group",
         "arguments": "non_uniform_3d_basic",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5639,6 +6444,7 @@
         "test_category": "non_uniform_work_group",
         "executable_path": "test_conformance/non_uniform_work_group/bin/test_non_uniform_work_group",
         "arguments": "non_uniform_3d_atomics",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5646,6 +6452,7 @@
         "test_category": "non_uniform_work_group",
         "executable_path": "test_conformance/non_uniform_work_group/bin/test_non_uniform_work_group",
         "arguments": "non_uniform_3d_barriers",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5653,6 +6460,7 @@
         "test_category": "non_uniform_work_group",
         "executable_path": "test_conformance/non_uniform_work_group/bin/test_non_uniform_work_group",
         "arguments": "non_uniform_other_basic",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5660,6 +6468,7 @@
         "test_category": "non_uniform_work_group",
         "executable_path": "test_conformance/non_uniform_work_group/bin/test_non_uniform_work_group",
         "arguments": "non_uniform_other_atomics",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5667,6 +6476,7 @@
         "test_category": "non_uniform_work_group",
         "executable_path": "test_conformance/non_uniform_work_group/bin/test_non_uniform_work_group",
         "arguments": "non_uniform_other_barriers",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5674,6 +6484,7 @@
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
         "arguments": "function_get_fence",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5681,6 +6492,7 @@
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
         "arguments": "function_to_address_space",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5688,6 +6500,7 @@
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
         "arguments": "variable_get_fence",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5695,6 +6508,7 @@
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
         "arguments": "variable_to_address_space",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5702,6 +6516,7 @@
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
         "arguments": "casting",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5709,6 +6524,7 @@
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
         "arguments": "conditional_casting",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5716,6 +6532,7 @@
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
         "arguments": "chain_casting",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5723,6 +6540,7 @@
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
         "arguments": "ternary_operator_casting",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5730,6 +6548,7 @@
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
         "arguments": "language_struct",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5737,6 +6556,7 @@
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
         "arguments": "language_union",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5744,6 +6564,7 @@
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
         "arguments": "multiple_calls_same_function",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5751,6 +6572,7 @@
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
         "arguments": "compare_pointers",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5758,6 +6580,7 @@
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
         "arguments": "library_function",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5765,6 +6588,7 @@
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
         "arguments": "generic_variable_volatile",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5772,6 +6596,7 @@
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
         "arguments": "generic_variable_const",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5779,6 +6604,7 @@
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
         "arguments": "generic_variable_gentype",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5786,6 +6612,7 @@
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
         "arguments": "builtin_functions",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5793,6 +6620,7 @@
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
         "arguments": "generic_advanced_casting",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5800,6 +6628,7 @@
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
         "arguments": "generic_ptr_to_host_mem",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5807,6 +6636,7 @@
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
         "arguments": "generic_ptr_to_host_mem_svm",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5814,6 +6644,7 @@
         "test_category": "generic_address_space",
         "executable_path": "test_conformance/generic_address_space/bin/test_generic_address_space",
         "arguments": "max_number_of_params",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5821,6 +6652,7 @@
         "test_category": "subgroups",
         "executable_path": "test_conformance/subgroups/bin/test_subgroups",
         "arguments": "sub_group_info_ext",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5828,6 +6660,7 @@
         "test_category": "subgroups",
         "executable_path": "test_conformance/subgroups/bin/test_subgroups",
         "arguments": "sub_group_info_core",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5835,6 +6668,7 @@
         "test_category": "subgroups",
         "executable_path": "test_conformance/subgroups/bin/test_subgroups",
         "arguments": "work_item_functions_ext",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5842,6 +6676,7 @@
         "test_category": "subgroups",
         "executable_path": "test_conformance/subgroups/bin/test_subgroups",
         "arguments": "work_item_functions_core",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5849,6 +6684,7 @@
         "test_category": "subgroups",
         "executable_path": "test_conformance/subgroups/bin/test_subgroups",
         "arguments": "subgroup_functions_ext",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5856,6 +6692,7 @@
         "test_category": "subgroups",
         "executable_path": "test_conformance/subgroups/bin/test_subgroups",
         "arguments": "subgroup_functions_core",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5863,6 +6700,7 @@
         "test_category": "subgroups",
         "executable_path": "test_conformance/subgroups/bin/test_subgroups",
         "arguments": "barrier_functions_ext",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5870,6 +6708,7 @@
         "test_category": "subgroups",
         "executable_path": "test_conformance/subgroups/bin/test_subgroups",
         "arguments": "barrier_functions_core",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5877,6 +6716,7 @@
         "test_category": "subgroups",
         "executable_path": "test_conformance/subgroups/bin/test_subgroups",
         "arguments": "ifp_ext",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5884,6 +6724,7 @@
         "test_category": "subgroups",
         "executable_path": "test_conformance/subgroups/bin/test_subgroups",
         "arguments": "ifp_core",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5891,6 +6732,7 @@
         "test_category": "subgroups",
         "executable_path": "test_conformance/subgroups/bin/test_subgroups",
         "arguments": "subgroup_functions_extended_types",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5898,6 +6740,7 @@
         "test_category": "subgroups",
         "executable_path": "test_conformance/subgroups/bin/test_subgroups",
         "arguments": "subgroup_functions_non_uniform_vote",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5905,6 +6748,7 @@
         "test_category": "subgroups",
         "executable_path": "test_conformance/subgroups/bin/test_subgroups",
         "arguments": "subgroup_functions_non_uniform_arithmetic",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5912,6 +6756,7 @@
         "test_category": "subgroups",
         "executable_path": "test_conformance/subgroups/bin/test_subgroups",
         "arguments": "subgroup_functions_ballot",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5919,6 +6764,7 @@
         "test_category": "subgroups",
         "executable_path": "test_conformance/subgroups/bin/test_subgroups",
         "arguments": "subgroup_functions_clustered_reduce",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5926,6 +6772,7 @@
         "test_category": "subgroups",
         "executable_path": "test_conformance/subgroups/bin/test_subgroups",
         "arguments": "subgroup_functions_shuffle",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5933,6 +6780,7 @@
         "test_category": "subgroups",
         "executable_path": "test_conformance/subgroups/bin/test_subgroups",
         "arguments": "subgroup_functions_shuffle_relative",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5940,6 +6788,7 @@
         "test_category": "workgroups",
         "executable_path": "test_conformance/workgroups/bin/test_workgroups",
         "arguments": "work_group_all",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5947,6 +6796,7 @@
         "test_category": "workgroups",
         "executable_path": "test_conformance/workgroups/bin/test_workgroups",
         "arguments": "work_group_any",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5954,6 +6804,7 @@
         "test_category": "workgroups",
         "executable_path": "test_conformance/workgroups/bin/test_workgroups",
         "arguments": "work_group_reduce_add",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5961,6 +6812,7 @@
         "test_category": "workgroups",
         "executable_path": "test_conformance/workgroups/bin/test_workgroups",
         "arguments": "work_group_reduce_min",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5968,6 +6820,7 @@
         "test_category": "workgroups",
         "executable_path": "test_conformance/workgroups/bin/test_workgroups",
         "arguments": "work_group_reduce_max",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5975,6 +6828,7 @@
         "test_category": "workgroups",
         "executable_path": "test_conformance/workgroups/bin/test_workgroups",
         "arguments": "work_group_scan_inclusive_add",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5982,6 +6836,7 @@
         "test_category": "workgroups",
         "executable_path": "test_conformance/workgroups/bin/test_workgroups",
         "arguments": "work_group_scan_inclusive_min",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5989,6 +6844,7 @@
         "test_category": "workgroups",
         "executable_path": "test_conformance/workgroups/bin/test_workgroups",
         "arguments": "work_group_scan_inclusive_max",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -5996,6 +6852,7 @@
         "test_category": "workgroups",
         "executable_path": "test_conformance/workgroups/bin/test_workgroups",
         "arguments": "work_group_scan_exclusive_add",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6003,6 +6860,7 @@
         "test_category": "workgroups",
         "executable_path": "test_conformance/workgroups/bin/test_workgroups",
         "arguments": "work_group_scan_exclusive_min",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6010,6 +6868,7 @@
         "test_category": "workgroups",
         "executable_path": "test_conformance/workgroups/bin/test_workgroups",
         "arguments": "work_group_scan_exclusive_max",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6017,6 +6876,7 @@
         "test_category": "workgroups",
         "executable_path": "test_conformance/workgroups/bin/test_workgroups",
         "arguments": "work_group_broadcast_1D",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6024,6 +6884,7 @@
         "test_category": "workgroups",
         "executable_path": "test_conformance/workgroups/bin/test_workgroups",
         "arguments": "work_group_broadcast_2D",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6031,6 +6892,7 @@
         "test_category": "workgroups",
         "executable_path": "test_conformance/workgroups/bin/test_workgroups",
         "arguments": "work_group_broadcast_3D",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6038,6 +6900,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_readwrite_int",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6045,6 +6908,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_readwrite_uint",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6052,6 +6916,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_readwrite_long",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6059,6 +6924,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_readwrite_ulong",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6066,6 +6932,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_readwrite_short",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6073,6 +6940,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_readwrite_ushort",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6080,6 +6948,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_readwrite_float",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6087,6 +6956,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_readwrite_half",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6094,6 +6964,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_readwrite_char",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6101,6 +6972,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_readwrite_uchar",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6108,6 +6980,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_readwrite_double",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6115,6 +6988,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_readwrite_struct",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6122,6 +6996,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_workgroup_readwrite_int",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6129,6 +7004,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_workgroup_readwrite_uint",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6136,6 +7012,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_workgroup_readwrite_long",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6143,6 +7020,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_workgroup_readwrite_ulong",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6150,6 +7028,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_workgroup_readwrite_short",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6157,6 +7036,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_workgroup_readwrite_ushort",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6164,6 +7044,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_workgroup_readwrite_float",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6171,6 +7052,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_workgroup_readwrite_half",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6178,6 +7060,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_workgroup_readwrite_char",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6185,6 +7068,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_workgroup_readwrite_uchar",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6192,6 +7076,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_workgroup_readwrite_double",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6199,6 +7084,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_workgroup_readwrite_struct",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6206,6 +7092,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_subgroup_readwrite_int",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6213,6 +7100,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_subgroup_readwrite_uint",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6220,6 +7108,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_subgroup_readwrite_long",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6227,6 +7116,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_subgroup_readwrite_ulong",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6234,6 +7124,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_subgroup_readwrite_short",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6241,6 +7132,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_subgroup_readwrite_ushort",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6248,6 +7140,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_subgroup_readwrite_float",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6255,6 +7148,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_subgroup_readwrite_half",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6262,6 +7156,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_subgroup_readwrite_char",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6269,6 +7164,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_subgroup_readwrite_uchar",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6276,6 +7172,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_subgroup_readwrite_double",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6283,6 +7180,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_subgroup_readwrite_struct",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6290,6 +7188,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_convenience_readwrite_int",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6297,6 +7196,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_convenience_readwrite_uint",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6304,6 +7204,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_convenience_readwrite_long",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6311,6 +7212,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_convenience_readwrite_ulong",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6318,6 +7220,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_convenience_readwrite_short",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6325,6 +7228,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_convenience_readwrite_ushort",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6332,6 +7236,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_convenience_readwrite_float",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6339,6 +7244,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_convenience_readwrite_half",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6346,6 +7252,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_convenience_readwrite_char",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6353,6 +7260,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_convenience_readwrite_uchar",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6360,6 +7268,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_convenience_readwrite_double",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6367,6 +7276,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_convenience_readwrite_struct",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6374,6 +7284,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_info",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6381,6 +7292,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_max_args",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6388,6 +7300,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_max_packet_size",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6395,6 +7308,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_max_active_reservations",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6402,6 +7316,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_query_functions",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6409,6 +7324,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_readwrite_errors",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6416,6 +7332,7 @@
         "test_category": "pipes",
         "executable_path": "test_conformance/pipes/bin/test_pipes",
         "arguments": "pipe_subgroups_divergence",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6423,6 +7340,7 @@
         "test_category": "device_timer",
         "executable_path": "test_conformance/device_timer/bin/test_device_timer",
         "arguments": "timer_resolution_queries",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6430,6 +7348,7 @@
         "test_category": "device_timer",
         "executable_path": "test_conformance/device_timer/bin/test_device_timer",
         "arguments": "device_and_host_timers",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6437,6 +7356,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "ext_cl_khr_spirv_no_integer_wrap_decoration_fadd_int",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6444,6 +7364,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "ext_cl_khr_spirv_no_integer_wrap_decoration_fsub_int",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6451,6 +7372,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "ext_cl_khr_spirv_no_integer_wrap_decoration_fmul_int",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6458,6 +7380,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "ext_cl_khr_spirv_no_integer_wrap_decoration_fshiftleft_int",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6465,6 +7388,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "ext_cl_khr_spirv_no_integer_wrap_decoration_fnegate_int",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6472,6 +7396,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "ext_cl_khr_spirv_no_integer_wrap_decoration_fadd_uint",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6479,6 +7404,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "ext_cl_khr_spirv_no_integer_wrap_decoration_fsub_uint",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6486,6 +7412,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "ext_cl_khr_spirv_no_integer_wrap_decoration_fmul_uint",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6493,6 +7420,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "ext_cl_khr_spirv_no_integer_wrap_decoration_fshiftleft_uint",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6500,6 +7428,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "decorate_restrict",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6507,6 +7436,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "decorate_aliased",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6514,6 +7444,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "decorate_alignment",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6521,6 +7452,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "decorate_constant",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6528,6 +7460,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "decorate_cpacked",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6535,6 +7468,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "decorate_saturated_conversion_char",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6542,6 +7476,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "decorate_saturated_conversion_uchar",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6549,6 +7484,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "decorate_saturated_conversion_short",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6556,6 +7492,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "decorate_saturated_conversion_ushort",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6563,6 +7500,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "decorate_saturated_conversion_int",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6570,6 +7508,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "decorate_saturated_conversion_uint",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6577,6 +7516,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "decorate_fp_rounding_mode_rte_float_int",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6584,6 +7524,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "decorate_fp_rounding_mode_rtz_float_int",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6591,6 +7532,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "decorate_fp_rounding_mode_rtp_float_int",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6598,6 +7540,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "decorate_fp_rounding_mode_rtn_float_int",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6605,6 +7548,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "decorate_fp_rounding_mode_rte_double_long",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6612,6 +7556,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "decorate_fp_rounding_mode_rtz_double_long",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6619,6 +7564,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "decorate_fp_rounding_mode_rtp_double_long",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6626,6 +7572,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "decorate_fp_rounding_mode_rtn_double_long",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6633,6 +7580,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "get_program_il",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6640,6 +7588,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "linkage_export_function_compile",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6647,6 +7596,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "linkage_import_function_compile",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6654,6 +7604,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "linkage_import_function_link",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6661,6 +7612,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_atomic_inc_global",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6668,6 +7620,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_atomic_dec_global",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6675,6 +7628,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_label_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6682,6 +7636,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_branch_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6689,6 +7644,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_unreachable_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6696,6 +7652,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_branch_conditional",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6703,6 +7660,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_branch_conditional_weighted",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6710,6 +7668,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_composite_construct_int4",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6717,6 +7676,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_composite_construct_struct",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6724,6 +7684,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_constant_true_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6731,6 +7692,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_constant_false_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6738,6 +7700,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_constant_int_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6745,6 +7708,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_constant_uint_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6752,6 +7716,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_constant_char_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6759,6 +7724,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_constant_uchar_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6766,6 +7732,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_constant_ushort_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6773,6 +7740,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_constant_long_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6780,6 +7748,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_constant_ulong_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6787,6 +7756,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_constant_short_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6794,6 +7764,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_constant_float_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6801,6 +7772,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_constant_double_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6808,6 +7780,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_constant_int4_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6815,6 +7788,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_constant_int3_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6822,6 +7796,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_constant_struct_int_float_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6829,6 +7804,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_constant_struct_int_char_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6836,6 +7812,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_constant_struct_struct_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6843,6 +7820,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_constant_half_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6850,6 +7828,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_copy_int_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6857,6 +7836,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_copy_uint_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6864,6 +7844,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_copy_char_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6871,6 +7852,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_copy_uchar_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6878,6 +7860,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_copy_ushort_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6885,6 +7868,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_copy_long_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6892,6 +7876,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_copy_ulong_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6899,6 +7884,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_copy_short_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6906,6 +7892,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_copy_float_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6913,6 +7900,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_copy_double_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6920,6 +7908,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_copy_int4_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6927,6 +7916,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_copy_int3_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6934,6 +7924,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_copy_struct_int_float_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6941,6 +7932,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_copy_struct_int_char_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6948,6 +7940,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_copy_struct_struct_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6955,6 +7948,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_copy_half_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6962,6 +7956,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fadd_float_regular",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6969,6 +7964,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fsub_float_regular",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6976,6 +7972,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fmul_float_regular",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6983,6 +7980,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fdiv_float_regular",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6990,6 +7988,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_frem_float_regular",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -6997,6 +7996,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fmod_float_regular",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7004,6 +8004,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fadd_float_fast",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7011,6 +8012,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fsub_float_fast",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7018,6 +8020,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fmul_float_fast",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7025,6 +8028,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fdiv_float_fast",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7032,6 +8036,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_frem_float_fast",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7039,6 +8044,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fmod_float_fast",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7046,6 +8052,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fadd_double_regular",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7053,6 +8060,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fsub_double_regular",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7060,6 +8068,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fmul_double_regular",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7067,6 +8076,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fdiv_double_regular",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7074,6 +8084,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_frem_double_regular",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7081,6 +8092,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fmod_double_regular",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7088,6 +8100,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fadd_double_fast",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7095,6 +8108,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fsub_double_fast",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7102,6 +8116,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fmul_double_fast",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7109,6 +8124,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fdiv_double_fast",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7116,6 +8132,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_frem_double_fast",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7123,6 +8140,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fmod_double_fast",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7130,6 +8148,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fadd_float4_regular",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7137,6 +8156,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fsub_float4_regular",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7144,6 +8164,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fmul_float4_regular",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7151,6 +8172,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fdiv_float4_regular",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7158,6 +8180,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_frem_float4_regular",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7165,6 +8188,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fmod_float4_regular",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7172,6 +8196,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fadd_float4_fast",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7179,6 +8204,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fsub_float4_fast",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7186,6 +8212,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fmul_float4_fast",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7193,6 +8220,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fdiv_float4_fast",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7200,6 +8228,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_frem_float4_fast",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7207,6 +8236,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fmod_float4_fast",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7214,6 +8244,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fadd_double2_regular",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7221,6 +8252,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fsub_double2_regular",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7228,6 +8260,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fmul_double2_regular",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7235,6 +8268,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fdiv_double2_regular",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7242,6 +8276,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_frem_double2_regular",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7249,6 +8284,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fmod_double2_regular",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7256,6 +8292,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fadd_double2_fast",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7263,6 +8300,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fsub_double2_fast",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7270,6 +8308,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fmul_double2_fast",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7277,6 +8316,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fdiv_double2_fast",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7284,6 +8324,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_frem_double2_fast",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7291,6 +8332,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fmod_double2_fast",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7298,6 +8340,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fadd_half_regular",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7305,6 +8348,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fsub_half_regular",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7312,6 +8356,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fmul_half_regular",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7319,6 +8364,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fdiv_half_regular",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7326,6 +8372,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_frem_half_regular",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7333,6 +8380,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fmod_half_regular",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7340,6 +8388,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fadd_half_fast",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7347,6 +8396,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fsub_half_fast",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7354,6 +8404,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fmul_half_fast",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7361,6 +8412,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fdiv_half_fast",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7368,6 +8420,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_frem_half_fast",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7375,6 +8428,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_fmod_half_fast",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7382,6 +8436,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "function_none",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7389,6 +8444,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "function_inline",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7396,6 +8452,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "function_noinline",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7403,6 +8460,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "function_pure",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7410,6 +8468,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "function_const",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7417,6 +8476,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "function_pure_ptr",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7424,6 +8484,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_lifetime_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7431,6 +8492,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_loop_merge_branch_none",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7438,6 +8500,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_loop_merge_branch_unroll",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7445,6 +8508,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_loop_merge_branch_dont_unroll",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7452,6 +8516,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_loop_merge_branch_conditional_none",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7459,6 +8524,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_loop_merge_branch_conditional_unroll",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7466,6 +8532,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_loop_merge_branch_conditional_dont_unroll",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7473,6 +8540,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_neg_float",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7480,6 +8548,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_neg_double",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7487,6 +8556,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_neg_int",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7494,6 +8564,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_neg_long",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7501,6 +8572,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_not_int",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7508,6 +8580,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_not_long",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7515,6 +8588,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_neg_short",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7522,6 +8596,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_not_short",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7529,6 +8604,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_neg_float4",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7536,6 +8612,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_neg_int4",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7543,6 +8620,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_not_int4",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7550,6 +8628,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_type_opaque_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7557,6 +8636,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_phi_2_blocks",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7564,6 +8644,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_phi_3_blocks",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7571,6 +8652,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_phi_4_blocks",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7578,6 +8660,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_selection_merge_if_none",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7585,6 +8668,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_selection_merge_if_flatten",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7592,6 +8676,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_selection_merge_if_dont_flatten",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7599,6 +8684,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_selection_merge_swith_none",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7606,6 +8692,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_selection_merge_swith_flatten",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7613,6 +8700,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_selection_merge_swith_dont_flatten",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7620,6 +8708,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_spec_constant_uint_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7627,6 +8716,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_spec_constant_uchar_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7634,6 +8724,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_spec_constant_ushort_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7641,6 +8732,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_spec_constant_ulong_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7648,6 +8740,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_spec_constant_float_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7655,6 +8748,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_spec_constant_half_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7662,6 +8756,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_spec_constant_double_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7669,6 +8764,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_spec_constant_true_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7676,6 +8772,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_spec_constant_false_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7683,6 +8780,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_undef_true_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7690,6 +8788,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_undef_false_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7697,6 +8796,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_undef_int_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7704,6 +8804,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_undef_uint_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7711,6 +8812,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_undef_char_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7718,6 +8820,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_undef_uchar_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7725,6 +8828,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_undef_ushort_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7732,6 +8836,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_undef_long_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7739,6 +8844,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_undef_ulong_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7746,6 +8852,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_undef_short_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7753,6 +8860,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_undef_float_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7760,6 +8868,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_undef_double_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7767,6 +8876,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_undef_int4_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7774,6 +8884,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_undef_int3_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7781,6 +8892,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_undef_struct_int_float_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7788,6 +8900,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_undef_struct_int_char_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7795,6 +8908,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_undef_struct_struct_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7802,6 +8916,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_undef_half_simple",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7809,6 +8924,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_vector_int4_extract",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7816,6 +8932,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_vector_float4_extract",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7823,6 +8940,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_vector_long2_extract",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7830,6 +8948,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_vector_double2_extract",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7837,6 +8956,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_vector_char16_extract",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7844,6 +8964,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_vector_int4_insert",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7851,6 +8972,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_vector_float4_insert",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7858,6 +8980,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_vector_long2_insert",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7865,6 +8988,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_vector_double2_insert",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7872,6 +8996,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_vector_char16_insert",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7879,6 +9004,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_vector_times_scalar_float",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7886,6 +9012,7 @@
         "test_category": "spirv_new",
         "executable_path": "test_conformance/spirv_new/bin/test_spirv_new",
         "arguments": "op_vector_times_scalar_double",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -7893,6 +9020,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "acos -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -7900,6 +9028,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "acosh -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -7907,6 +9036,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "acospi -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -7914,6 +9044,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "add -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -7921,6 +9052,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "asin -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -7928,6 +9060,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "asinh -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -7935,6 +9068,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "asinpi -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -7942,6 +9076,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "assignment -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -7949,6 +9084,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "atan -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -7956,6 +9092,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "atan2 -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -7963,6 +9100,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "atan2pi -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -7970,6 +9108,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "atanh -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -7977,6 +9116,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "atanpi -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -7984,6 +9124,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "cbrt -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -7991,6 +9132,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "ceil -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -7998,6 +9140,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "copysign -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8005,6 +9148,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "cos -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8012,6 +9156,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "cosh -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8019,6 +9164,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "cospi -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8026,6 +9172,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "divide -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8033,6 +9180,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "divide_cr -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8040,6 +9188,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "exp -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8047,6 +9196,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "exp10 -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8054,6 +9204,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "exp2 -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8061,6 +9212,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "expm1 -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8068,6 +9220,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "fabs -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8075,6 +9228,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "fdim -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8082,6 +9236,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "floor -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8089,6 +9244,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "fma -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8096,6 +9252,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "fmax -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8103,6 +9260,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "fmin -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8110,6 +9268,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "fmod -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8117,6 +9276,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "fract -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8124,6 +9284,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "frexp -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8131,6 +9292,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "half_cos -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8138,6 +9300,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "half_divide -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8145,6 +9308,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "half_exp -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8152,6 +9316,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "half_exp10 -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8159,6 +9324,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "half_exp2 -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8166,6 +9332,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "half_log -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8173,6 +9340,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "half_log10 -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8180,6 +9348,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "half_log2 -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8187,6 +9356,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "half_powr -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8194,6 +9364,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "half_recip -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8201,6 +9372,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "half_rsqrt -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8208,6 +9380,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "half_sin -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8215,6 +9388,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "half_sqrt -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8222,6 +9396,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "half_tan -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8229,6 +9404,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "hypot -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8236,6 +9412,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "ilogb -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8243,6 +9420,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "isequal -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8250,6 +9428,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "isfinite -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8257,6 +9436,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "isgreater -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8264,6 +9444,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "isgreaterequal -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8271,6 +9452,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "isinf -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8278,6 +9460,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "isless -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8285,6 +9468,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "islessequal -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8292,6 +9476,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "islessgreater -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8299,6 +9484,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "isnan -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8306,6 +9492,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "isnormal -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8313,6 +9500,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "isnotequal -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8320,6 +9508,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "isordered -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8327,6 +9516,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "isunordered -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8334,6 +9524,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "ldexp -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8341,6 +9532,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "lgamma -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8348,6 +9540,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "lgamma_r -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8355,6 +9548,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "log -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8362,6 +9556,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "log10 -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8369,6 +9564,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "log1p -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8376,6 +9572,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "log2 -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8383,6 +9580,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "logb -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8390,6 +9588,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "mad -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8397,6 +9596,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "maxmag -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8404,6 +9604,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "minmag -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8411,6 +9612,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "modf -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8418,6 +9620,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "multiply -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8425,6 +9628,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "nan -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8432,6 +9636,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "nextafter -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8439,6 +9644,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "not -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8446,6 +9652,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "pow -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8453,6 +9660,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "pown -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8460,6 +9668,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "powr -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8467,6 +9676,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "remainder -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8474,6 +9684,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "remquo -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8481,6 +9692,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "rint -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8488,6 +9700,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "rootn -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8495,6 +9708,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "round -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8502,6 +9716,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "rsqrt -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8509,6 +9724,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "signbit -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8516,6 +9732,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "sin -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8523,6 +9740,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "sincos -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8530,6 +9748,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "sinh -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8537,6 +9756,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "sinpi -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8544,6 +9764,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "sqrt -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8551,6 +9772,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "sqrt_cr -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8558,6 +9780,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "subtract -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8565,6 +9788,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "tan -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8572,6 +9796,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "tanh -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8579,6 +9804,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "tanpi -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8586,6 +9812,7 @@
         "test_category": "math_brute_force",
         "executable_path": "test_conformance/math_brute_force/bin/test_bruteforce",
         "arguments": "trunc -m -s -v",
+        "environment": "",
         "time_limit": 480
     },
     {
@@ -8593,6 +9820,7 @@
         "test_category": "SVM",
         "executable_path": "test_conformance/SVM/bin/test_svm",
         "arguments": "svm_byte_granularity",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8600,6 +9828,7 @@
         "test_category": "SVM",
         "executable_path": "test_conformance/SVM/bin/test_svm",
         "arguments": "svm_set_kernel_exec_info_svm_ptrs",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8607,6 +9836,7 @@
         "test_category": "SVM",
         "executable_path": "test_conformance/SVM/bin/test_svm",
         "arguments": "svm_fine_grain_memory_consistency",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8614,6 +9844,7 @@
         "test_category": "SVM",
         "executable_path": "test_conformance/SVM/bin/test_svm",
         "arguments": "svm_fine_grain_sync_buffers",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8621,6 +9852,7 @@
         "test_category": "SVM",
         "executable_path": "test_conformance/SVM/bin/test_svm",
         "arguments": "svm_shared_address_space_fine_grain",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8628,6 +9860,7 @@
         "test_category": "SVM",
         "executable_path": "test_conformance/SVM/bin/test_svm",
         "arguments": "svm_shared_sub_buffers",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8635,6 +9868,7 @@
         "test_category": "SVM",
         "executable_path": "test_conformance/SVM/bin/test_svm",
         "arguments": "svm_shared_address_space_fine_grain_buffers",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8642,6 +9876,7 @@
         "test_category": "SVM",
         "executable_path": "test_conformance/SVM/bin/test_svm",
         "arguments": "svm_allocate_shared_buffer",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8649,6 +9884,7 @@
         "test_category": "SVM",
         "executable_path": "test_conformance/SVM/bin/test_svm",
         "arguments": "svm_shared_address_space_coarse_grain_old_api",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8656,6 +9892,7 @@
         "test_category": "SVM",
         "executable_path": "test_conformance/SVM/bin/test_svm",
         "arguments": "svm_shared_address_space_coarse_grain_new_api",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8663,6 +9900,7 @@
         "test_category": "SVM",
         "executable_path": "test_conformance/SVM/bin/test_svm",
         "arguments": "svm_cross_buffer_pointers_coarse_grain",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8670,6 +9908,7 @@
         "test_category": "SVM",
         "executable_path": "test_conformance/SVM/bin/test_svm",
         "arguments": "svm_pointer_passing",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8677,6 +9916,7 @@
         "test_category": "SVM",
         "executable_path": "test_conformance/SVM/bin/test_svm",
         "arguments": "svm_enqueue_api",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8684,6 +9924,7 @@
         "test_category": "SVM",
         "executable_path": "test_conformance/SVM/bin/test_svm",
         "arguments": "svm_migrate",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8691,6 +9932,7 @@
         "test_category": "clCopyImage",
         "executable_path": "test_conformance/images/clCopyImage/bin/test_cl_copy_images",
         "arguments": "1D",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8698,6 +9940,7 @@
         "test_category": "clCopyImage",
         "executable_path": "test_conformance/images/clCopyImage/bin/test_cl_copy_images",
         "arguments": "2D",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8705,6 +9948,7 @@
         "test_category": "clCopyImage",
         "executable_path": "test_conformance/images/clCopyImage/bin/test_cl_copy_images",
         "arguments": "3D",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8712,6 +9956,7 @@
         "test_category": "clCopyImage",
         "executable_path": "test_conformance/images/clCopyImage/bin/test_cl_copy_images",
         "arguments": "1Darray",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8719,6 +9964,7 @@
         "test_category": "clCopyImage",
         "executable_path": "test_conformance/images/clCopyImage/bin/test_cl_copy_images",
         "arguments": "2Darray",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8726,6 +9972,7 @@
         "test_category": "clCopyImage",
         "executable_path": "test_conformance/images/clCopyImage/bin/test_cl_copy_images",
         "arguments": "2Dto3D",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8733,6 +9980,7 @@
         "test_category": "clCopyImage",
         "executable_path": "test_conformance/images/clCopyImage/bin/test_cl_copy_images",
         "arguments": "3Dto2D",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8740,6 +9988,7 @@
         "test_category": "clCopyImage",
         "executable_path": "test_conformance/images/clCopyImage/bin/test_cl_copy_images",
         "arguments": "2Darrayto2D",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8747,6 +9996,7 @@
         "test_category": "clCopyImage",
         "executable_path": "test_conformance/images/clCopyImage/bin/test_cl_copy_images",
         "arguments": "2Dto2Darray",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8754,6 +10004,7 @@
         "test_category": "clCopyImage",
         "executable_path": "test_conformance/images/clCopyImage/bin/test_cl_copy_images",
         "arguments": "2Darrayto3D",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8761,6 +10012,7 @@
         "test_category": "clCopyImage",
         "executable_path": "test_conformance/images/clCopyImage/bin/test_cl_copy_images",
         "arguments": "3Dto2Darray",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8768,6 +10020,7 @@
         "test_category": "clFillImage",
         "executable_path": "test_conformance/images/clFillImage/bin/test_cl_fill_images",
         "arguments": "1D",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8775,6 +10028,7 @@
         "test_category": "clFillImage",
         "executable_path": "test_conformance/images/clFillImage/bin/test_cl_fill_images",
         "arguments": "2D",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8782,6 +10036,7 @@
         "test_category": "clFillImage",
         "executable_path": "test_conformance/images/clFillImage/bin/test_cl_fill_images",
         "arguments": "3D",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8789,6 +10044,7 @@
         "test_category": "clFillImage",
         "executable_path": "test_conformance/images/clFillImage/bin/test_cl_fill_images",
         "arguments": "1Darray",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8796,6 +10052,7 @@
         "test_category": "clFillImage",
         "executable_path": "test_conformance/images/clFillImage/bin/test_cl_fill_images",
         "arguments": "2Darray",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8803,6 +10060,7 @@
         "test_category": "clGetInfo",
         "executable_path": "test_conformance/images/clGetInfo/bin/test_cl_get_info",
         "arguments": "1D",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8810,6 +10068,7 @@
         "test_category": "clGetInfo",
         "executable_path": "test_conformance/images/clGetInfo/bin/test_cl_get_info",
         "arguments": "2D",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8817,6 +10076,7 @@
         "test_category": "clGetInfo",
         "executable_path": "test_conformance/images/clGetInfo/bin/test_cl_get_info",
         "arguments": "3D",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8824,6 +10084,7 @@
         "test_category": "clGetInfo",
         "executable_path": "test_conformance/images/clGetInfo/bin/test_cl_get_info",
         "arguments": "1Darray",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8831,6 +10092,7 @@
         "test_category": "clGetInfo",
         "executable_path": "test_conformance/images/clGetInfo/bin/test_cl_get_info",
         "arguments": "2Darray",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8838,6 +10100,7 @@
         "test_category": "clReadWriteImage",
         "executable_path": "test_conformance/images/clReadWriteImage/bin/test_cl_read_write_images",
         "arguments": "1D",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8845,6 +10108,7 @@
         "test_category": "clReadWriteImage",
         "executable_path": "test_conformance/images/clReadWriteImage/bin/test_cl_read_write_images",
         "arguments": "2D",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8852,6 +10116,7 @@
         "test_category": "clReadWriteImage",
         "executable_path": "test_conformance/images/clReadWriteImage/bin/test_cl_read_write_images",
         "arguments": "3D",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8859,6 +10124,7 @@
         "test_category": "clReadWriteImage",
         "executable_path": "test_conformance/images/clReadWriteImage/bin/test_cl_read_write_images",
         "arguments": "1Darray",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8866,6 +10132,7 @@
         "test_category": "clReadWriteImage",
         "executable_path": "test_conformance/images/clReadWriteImage/bin/test_cl_read_write_images",
         "arguments": "2Darray",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8873,6 +10140,7 @@
         "test_category": "kernel_image_methods",
         "executable_path": "test_conformance/images/kernel_image_methods/bin/test_kernel_image_methods",
         "arguments": "1D",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8880,6 +10148,7 @@
         "test_category": "kernel_image_methods",
         "executable_path": "test_conformance/images/kernel_image_methods/bin/test_kernel_image_methods",
         "arguments": "2D",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8887,6 +10156,7 @@
         "test_category": "kernel_image_methods",
         "executable_path": "test_conformance/images/kernel_image_methods/bin/test_kernel_image_methods",
         "arguments": "3D",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8894,6 +10164,7 @@
         "test_category": "kernel_image_methods",
         "executable_path": "test_conformance/images/kernel_image_methods/bin/test_kernel_image_methods",
         "arguments": "1Darray",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8901,6 +10172,7 @@
         "test_category": "kernel_image_methods",
         "executable_path": "test_conformance/images/kernel_image_methods/bin/test_kernel_image_methods",
         "arguments": "2Darray",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8908,6 +10180,7 @@
         "test_category": "kernel_read_write",
         "executable_path": "test_conformance/images/kernel_read_write/bin/test_image_streams",
         "arguments": "1D",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8915,6 +10188,7 @@
         "test_category": "kernel_read_write",
         "executable_path": "test_conformance/images/kernel_read_write/bin/test_image_streams",
         "arguments": "2D",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8922,6 +10196,7 @@
         "test_category": "kernel_read_write",
         "executable_path": "test_conformance/images/kernel_read_write/bin/test_image_streams",
         "arguments": "3D",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8929,6 +10204,7 @@
         "test_category": "kernel_read_write",
         "executable_path": "test_conformance/images/kernel_read_write/bin/test_image_streams",
         "arguments": "1Darray",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8936,6 +10212,7 @@
         "test_category": "kernel_read_write",
         "executable_path": "test_conformance/images/kernel_read_write/bin/test_image_streams",
         "arguments": "2Darray",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8943,6 +10220,7 @@
         "test_category": "samplerlessReads",
         "executable_path": "test_conformance/images/samplerlessReads/bin/test_samplerless_reads",
         "arguments": "1D",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8950,6 +10228,7 @@
         "test_category": "samplerlessReads",
         "executable_path": "test_conformance/images/samplerlessReads/bin/test_samplerless_reads",
         "arguments": "2D",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8957,6 +10236,7 @@
         "test_category": "samplerlessReads",
         "executable_path": "test_conformance/images/samplerlessReads/bin/test_samplerless_reads",
         "arguments": "3D",
+        "environment": "",
         "time_limit": 120
     },
     {
@@ -8964,6 +10244,7 @@
         "test_category": "samplerlessReads",
         "executable_path": "test_conformance/images/samplerlessReads/bin/test_samplerless_reads",
         "arguments": "1Darray",
+        "environment": "",
         "time_limit": 120
     },
     {

--- a/tester/runner.py
+++ b/tester/runner.py
@@ -171,6 +171,7 @@ def _run_cts_test(test_category: str, test_name: str) -> CTSResult:
     """
     test_executable = get_cts_test_executable_absolute_path(test_category, test_name)
     test_arguments = get_cts_test_arguments(test_category, test_name)
+    test_environment = get_cts_test_environment(test_category, test_name)
     test_time_limit = get_cts_test_time_limit(test_category, test_name)
 
     # Prepare a temporary directory for dump files.
@@ -186,6 +187,9 @@ def _run_cts_test(test_category: str, test_name: str) -> CTSResult:
     environment["IGC_ShaderDumpEnable"] = "1"
     environment["IGC_ShaderDumpPidDisable"] = "1"
     environment["IGC_DumpToCustomDir"] = dumps_directory_path
+
+    for variable in test_environment:
+        environment[variable] = "1"
 
     # Start the test.
     start_time = datetime.now()


### PR DESCRIPTION
After this change some integer_ops tests will run with CL_TEST_SINGLE_THREADED=1 environment variable and higher 8 hr time limit.

Running the tests in a single-threaded environment makes it easier to debug potential issues using generated kernel dumps.